### PR TITLE
Update Airbrake config for v5.4 compatibility

### DIFF
--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -2,9 +2,9 @@ if ENV["ERRBIT_API_KEY"].present?
   errbit_uri = Plek.find_uri("errbit")
 
   Airbrake.configure do |config|
-    config.api_key = ENV["ERRBIT_API_KEY"]
-    config.host = errbit_uri.host
-    config.secure = errbit_uri.scheme == "https"
+    config.project_key = ENV["ERRBIT_API_KEY"]
+    config.project_id = 9999 # This is required by airbrake but ignored by errbit.
+    config.host = errbit_uri.to_s
     config.environment_name = ENV["ERRBIT_ENVIRONMENT_NAME"]
   end
 end


### PR DESCRIPTION
https://deploy.integration.publishing.service.gov.uk/job/Deploy_App/12051/console
The application deployment fails because of incompatible Airbrake config.