### PR TITLE
This migration isn't necessary any more

### DIFF
--- a/db/migrate/20170404125450_rename_check_warnings_and_errors.rb
+++ b/db/migrate/20170404125450_rename_check_warnings_and_errors.rb
@@ -1,6 +1,0 @@
-class RenameCheckWarningsAndErrors < ActiveRecord::Migration[5.0]
-  def change
-    rename_column :checks, :errors, :link_errors
-    rename_column :checks, :warnings, :link_warnings
-  end
-end


### PR DESCRIPTION
This migration isn't necessary as the Checks table is [properly defined here](https://github.com/alphagov/link-checker-api/blob/master/db/migrate/20170403153631_create_checks.rb#L6-L7)