### PR TITLE
Airbrake configuration for 5.8.1

### DIFF
--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -1,10 +1,11 @@
-if ENV["ERRBIT_API_KEY"].present?
-  errbit_uri = Plek.find_uri("errbit")
+errbit_uri = Plek.find_uri("errbit")
+environment = ENV.fetch("ERRBIT_ENVIRONMENT_NAME", Rails.env)
 
-  Airbrake.configure do |config|
-    config.project_key = ENV["ERRBIT_API_KEY"]
-    config.project_id = 9999 # This is required by airbrake but ignored by errbit.
-    config.host = errbit_uri.to_s
-    config.environment = ENV["ERRBIT_ENVIRONMENT_NAME"]
-  end
+Airbrake.configure do |config|
+  # we need a key even if errbit isn't used, so fall back to random data
+  config.project_key = ENV.fetch("ERRBIT_API_KEY", SecureRandom.hex(5))
+  config.project_id = 1 # dummy, not used in Errbit
+  config.host = errbit_uri.to_s
+  config.environment = environment
+  config.ignore_environments = ENV["ERRBIT_API_KEY"] ? [environment] : []
 end


### PR DESCRIPTION
With the change to 5.8.1 our previous approach of only configuring
Airbrake if there is a ENV var seems to fail with "undefined method
`build_notice’ for nil:NilClass" errors - as it expects Airbrake to be
configured. This adds configuration in for all environments, but the
environment is ignored if there is not a ERRBIT_API_KEY env var.