### PR TITLE
Run db:environment:set before tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,5 +2,7 @@
 
 node {
   def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
-  govuk.buildProject()
+  govuk.buildProject([
+    beforeTest: { -> sh("bundle exec rake db:environment:set") }
+  ])
 }


### PR DESCRIPTION
Without this Rails will abort with:
```
rake aborted!
ActiveRecord::NoEnvironmentInSchemaError:

Environment data not found in the schema. To resolve this issue, run:

        bin/rails db:environment:set RAILS_ENV=test

This should probably be in https://github.com/alphagov/govuk-puppet/blob/5e9f6285eb851ad1caae996fedf3f27622365449/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
for Rails 5 apps.
```