### PR TITLE
Avoid Google Safebrowsing check if there is no API key

### DIFF
--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -12,7 +12,7 @@
 
 development:
   secret_key_base: 36746f0eb3c57b16be0278bdf9a9418ec225ecd5f9a3183697a3dc0dfd3aa1d05d285b3ed42b77c92ae6deee7af6a2b9bc87f119eca9c74810dcc43ddd5eb02b
-  google_api_key: <%= ENV["GOOGLE_API_KEY"] || "development" %>
+  google_api_key: <%= ENV["GOOGLE_API_KEY"] %>
 
 test:
   secret_key_base: b81a573d7703bfdf5c80f2a201c9e9d7ec5aad3326e252534568e1a82a7fc79a09f0d8ebd5e7e0fb5fc584f6a23440f2be5c986ec723df389ef7527e3e7ffc12

--- a/lib/link_checker/uri_checker/http_checker.rb
+++ b/lib/link_checker/uri_checker/http_checker.rb
@@ -92,6 +92,7 @@ module LinkChecker::UriChecker
 
     def check_google_safebrowsing
       api_key = Rails.application.secrets.google_api_key
+      return unless api_key
 
       response = Faraday.post do |req|
         req.url "https://safebrowsing.googleapis.com/v4/threatMatches:find?key=#{api_key}"


### PR DESCRIPTION
Closes #33.