### PR TITLE
Only include rspec-sidekiq in testing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,8 +26,11 @@ group :development, :test do
   gem "timecop"
   gem "webmock"
   gem "rspec-rails", "~> 3.4"
-  gem "rspec-sidekiq", "~> 3.0"
   gem "byebug" # Comes standard with Rails
+end
+
+group :test do
+  gem "rspec-sidekiq", "~> 3.0"
 end
 
 group :development do


### PR DESCRIPTION
rspec-sidekiq does some things which means the workers are never run,
if we leave this on in development, the workers are never run while
trying to use the app.