### PR TITLE
Fix CheckWorker bug

### DIFF
--- a/app/workers/check_worker.rb
+++ b/app/workers/check_worker.rb
@@ -37,7 +37,7 @@ class CheckWorker
   def trigger_callbacks(check)
     check.batches.each do |batch|
       WebhookWorker.perform_async(
-        BatchPresenter.new(batch).call,
+        BatchPresenter.new(batch).report,
         batch.webhook_uri
       ) if batch.webhook_uri
     end


### PR DESCRIPTION
CheckWorker was calling `call` on BatchPresenter, which doesn't exist.  This
has now been changed to `report`.