### PR TITLE
Remove progress webhooks

### DIFF
--- a/app/workers/check_worker.rb
+++ b/app/workers/check_worker.rb
@@ -39,7 +39,7 @@ class CheckWorker
       WebhookWorker.perform_async(
         BatchPresenter.new(batch).report,
         batch.webhook_uri
-      ) if batch.webhook_uri
+      ) if batch.webhook_uri && batch.completed?
     end
   end
 end


### PR DESCRIPTION
We can bring them back if they prove useful.

Closes #46.