### PR TITLE
Fallback to Airbrake 4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem "database_cleaner"
 gem "deprecated_columns"
 gem "gds-sso", "~> 13.0"
 gem "plek", "~> 1.12"
-gem "airbrake", "~> 5.4"
+gem "airbrake", "~> 4"
 gem "pg"
 
 gem "faraday", "~> 0.11"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,9 +43,9 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.1)
       public_suffix (~> 2.0, >= 2.0.2)
-    airbrake (5.8.1)
-      airbrake-ruby (~> 1.8)
-    airbrake-ruby (1.8.0)
+    airbrake (4.3.8)
+      builder
+      multi_json
     arel (7.1.4)
     ast (2.3.0)
     binding_of_caller (0.7.2)
@@ -304,7 +304,7 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-import (~> 0.17)
-  airbrake (~> 5.4)
+  airbrake (~> 4)
   byebug
   database_cleaner
   deprecated_columns

--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -1,11 +1,10 @@
-errbit_uri = Plek.find_uri("errbit")
-environment = ENV.fetch("ERRBIT_ENVIRONMENT_NAME", Rails.env)
+if ENV['ERRBIT_API_KEY'].present?
+  errbit_uri = Plek.find_uri('errbit')
 
-Airbrake.configure do |config|
-  # we need a key even if errbit isn't used, so fall back to random data
-  config.project_key = ENV.fetch("ERRBIT_API_KEY", SecureRandom.hex(5))
-  config.project_id = 1 # dummy, not used in Errbit
-  config.host = errbit_uri.to_s
-  config.environment = environment
-  config.ignore_environments = ENV["ERRBIT_API_KEY"] ? [] : [environment]
+  Airbrake.configure do |config|
+    config.api_key = ENV['ERRBIT_API_KEY']
+    config.host = errbit_uri.host
+    config.secure = errbit_uri.scheme == 'https'
+    config.environment_name = ENV['ERRBIT_ENVIRONMENT_NAME']
+  end
 end


### PR DESCRIPTION
It turns out that you can't start afresh with Airbrake 5 with our
version of Errbit, at least that seems to be the case with our limited
time experimenting - theory being that it needs a deployment logged to
get started and our Errbit doesn't support Airbrake 5 deployments (or
Airbrake dropped them).

Since Airbrake 5 support with our Errbit is a bit flaky anyway rather
than doing a song and dance to get Airbrake 5 support, lets just
fall back to 4.