### PR TITLE
Order webhook workers with highest priority

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -2,9 +2,9 @@
 :concurrency: 4
 :logfile: ./log/sidekiq.json.log
 :queues:
+  - webhooks
   - default
   - checks_low
-  - webhooks
 :schedule:
   cleanup:
     every: 20m


### PR DESCRIPTION
This means they happen the moment they can.