### PR TITLE
Disable check for Google Safebrowsing API

### DIFF
--- a/lib/link_checker/uri_checker/http_checker.rb
+++ b/lib/link_checker/uri_checker/http_checker.rb
@@ -105,7 +105,9 @@ module LinkChecker::UriChecker
       check_meta_mature_rating
       return report if report.has_errors?
 
-      check_google_safebrowsing
+      # disabled for the moment until we can sort out a process for getting
+      # permentant staging and production keys
+      # check_google_safebrowsing
 
       report
     end

--- a/spec/lib/link_checker_spec.rb
+++ b/spec/lib/link_checker_spec.rb
@@ -236,16 +236,16 @@ RSpec.describe LinkChecker do
       include_examples "has no errors"
     end
 
-    context "a URL detected by Google Safebrowser API" do
-      let(:uri) { "http://malware.testing.google.test/testing/malware/" }
-      before do
-        stub_request(:get, uri).to_return(status: 200)
-        stub_request(:post, "https://safebrowsing.googleapis.com/v4/threatMatches:find?key=test")
-          .to_return(status: 200, body: { matches: [{ threatType: "MALWARE" }] }.to_json)
-      end
-      include_examples "has a problem summary", "Suspicious content"
-      include_examples "has warnings"
-      include_examples "has no errors"
-    end
+    # context "a URL detected by Google Safebrowser API" do
+    #   let(:uri) { "http://malware.testing.google.test/testing/malware/" }
+    #   before do
+    #     stub_request(:get, uri).to_return(status: 200)
+    #     stub_request(:post, "https://safebrowsing.googleapis.com/v4/threatMatches:find?key=test")
+    #       .to_return(status: 200, body: { matches: [{ threatType: "MALWARE" }] }.to_json)
+    #   end
+    #   include_examples "has a problem summary", "Suspicious content"
+    #   include_examples "has warnings"
+    #   include_examples "has no errors"
+    # end
   end
 end


### PR DESCRIPTION
Turns out the API key automatically gets disabled every day,
disabling this for now until we can get a production and staging
key set up properly.