### PR TITLE
Delete checks older than 4 weeks ago

### DIFF
--- a/app/workers/cleanup_worker.rb
+++ b/app/workers/cleanup_worker.rb
@@ -4,12 +4,27 @@ class CleanupWorker
   include Sidekiq::Worker
 
   def perform
-    check_ids.each do |check_id|
+    checks_to_perform.each do |check_id|
       CheckWorker.perform_async(check_id)
     end
+
+    old_batches.delete_all
+    old_checks.delete_all
   end
 
-  def check_ids
+private
+
+  OLD_CHECK_THRESHOLD = 4.weeks.ago
+
+  def checks_to_perform
     Check.requires_checking.pluck(:id)
+  end
+
+  def old_checks
+    Check.where("completed_at < ?", OLD_CHECK_THRESHOLD)
+  end
+
+  def old_batches
+    Batch.where(id: [BatchCheck.where(check: [old_checks]).pluck(:batch_id)])
   end
 end

--- a/db/migrate/20170707070733_add_deletion_cascade_to_batches_and_checks.rb
+++ b/db/migrate/20170707070733_add_deletion_cascade_to_batches_and_checks.rb
@@ -1,0 +1,6 @@
+class AddDeletionCascadeToBatchesAndChecks < ActiveRecord::Migration[5.0]
+  def change
+    remove_foreign_key :batch_checks, :batches
+    add_foreign_key :batch_checks, :batches, on_delete: :cascade
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -64,7 +64,7 @@ ActiveRecord::Schema.define(version: 20170713101143) do
     t.datetime "updated_at"
   end
 
-  add_foreign_key "batch_checks", "batches"
+  add_foreign_key "batch_checks", "batches", on_delete: :cascade
   add_foreign_key "batch_checks", "checks"
   add_foreign_key "checks", "links"
 end

--- a/spec/workers/cleanup_worker_spec.rb
+++ b/spec/workers/cleanup_worker_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe CleanupWorker do
+  describe "perform" do
+    let(:link1) { FactoryGirl.create(:link, id: 1) }
+    let(:link2) { FactoryGirl.create(:link, id: 2) }
+
+    context "with an old check" do
+      let(:check1) { FactoryGirl.create(:check, link: link1, completed_at: 10.weeks.ago) }
+      let(:check2) { FactoryGirl.create(:check, link: link2, completed_at: 2.weeks.ago) }
+      let!(:batch1) { FactoryGirl.create(:batch, checks: [check1]) }
+      let!(:batch2) { FactoryGirl.create(:batch, checks: [check2]) }
+      let!(:batch3) { FactoryGirl.create(:batch, checks: [check1, check2]) }
+
+      it "removes the check and the associated batches" do
+        expect(Check.count).to eq(2)
+        expect(Batch.count).to eq(3)
+
+        subject.perform
+
+        expect(Check.count).to eq(1)
+        expect(Batch.count).to eq(1)
+        expect(Check.first).to eq(check2)
+        expect(Batch.first).to eq(batch2)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This avoids the database getting full really quickly.

[Trello Card](https://trello.com/c/oItrI1Jm/972-clear-out-old-checks)