### PR TITLE
Only report on slow loading if the page could be loaded

### DIFF
--- a/lib/link_checker/uri_checker/http_checker.rb
+++ b/lib/link_checker/uri_checker/http_checker.rb
@@ -148,9 +148,9 @@ module LinkChecker::UriChecker
       end_time = Time.now
       response_time = end_time - start_time
 
-      add_problem(SlowResponse.new(from_redirect: from_redirect?)) if response_time > RESPONSE_TIME_WARNING
-
       return response if report.has_errors?
+
+      add_problem(SlowResponse.new(from_redirect: from_redirect?)) if response_time > RESPONSE_TIME_WARNING
 
       if response.status == 404 || response.status == 410
         add_problem(PageNotFound.new(from_redirect: from_redirect?))


### PR DESCRIPTION
This lead to a strange combination of errors where the host would
be unavailable, but you would also see a warning saying it was
slow to load.