### PR TITLE
Change default checked_within period

### DIFF
--- a/app/controllers/batch_controller.rb
+++ b/app/controllers/batch_controller.rb
@@ -11,7 +11,7 @@ class BatchController < ApplicationController
     def initialize(params)
       @params = params
       @uris = permitted_params[:uris]
-      @checked_within = (permitted_params[:checked_within] || 24.hours).to_i
+      @checked_within = (permitted_params[:checked_within] || 4.hours).to_i
       @priority = permitted_params.fetch(:priority, "high")
       @webhook_uri = permitted_params[:webhook_uri]
       @webhook_secret_token = permitted_params[:webhook_secret_token]

--- a/app/controllers/check_controller.rb
+++ b/app/controllers/check_controller.rb
@@ -13,7 +13,7 @@ class CheckController < ApplicationController
       @params = params
       @uri = permitted_params[:uri]
       @synchronous = permitted_params[:synchronous] == "true"
-      @checked_within = (permitted_params[:checked_within] || 24.hours).to_i
+      @checked_within = (permitted_params[:checked_within] || 4.hours).to_i
       @priority = permitted_params.fetch(:priority, "high")
     end
 

--- a/app/models/check.rb
+++ b/app/models/check.rb
@@ -9,7 +9,7 @@ class Check < ApplicationRecord
   scope :created_within, -> (within) { where("created_at > ?", Time.now - within) }
   scope :requires_checking, -> { where(started_at: nil).or(Check.where(completed_at: nil).where("created_at < ?", RECHECK_THRESHOLD)) }
 
-  def self.fetch_all(links, within: 24.hours)
+  def self.fetch_all(links, within: 4.hours)
     existing_checks = Check
       .created_within(within)
       .where(link: links)

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -15,7 +15,7 @@ class Link < ApplicationRecord
     existing_links + new_links.select { |link| import_result.ids.include?(link.id) }
   end
 
-  def find_check(within: 24.hours, completed: false)
+  def find_check(within: 4.hours, completed: false)
     scope = checks.created_within(within)
     scope = scope.where.not(completed_at: nil) if completed
     scope.order(:created_at).first

--- a/docs/api.md
+++ b/docs/api.md
@@ -53,7 +53,7 @@ $ curl -s http://link-checker-api.dev.gov.uk/check\?uri\=https%3A%2F%2Fwww.gov.u
 </details>
 
 This endpoint is used to check a single link. If the link has been checked
-within a time specified (default 24 hours) it will return the results from
+within a time specified (default 4 hours) it will return the results from
 that check, otherwise it will queue a check and return a pending report. You
 can force it to return a completed check with the `synchronous` parameter.
 
@@ -61,7 +61,7 @@ can force it to return a completed check with the `synchronous` parameter.
 
 - `uri` *(required)*
   - The URI to the link to be checked
-- `checked_within` *(optional, defaults to 86400)*
+- `checked_within` *(optional, defaults to 14400)*
   - An integer value of the number of seconds in the past that checks for this
     link are valid.
   - Use 0 to ensure the link is checked again
@@ -135,7 +135,7 @@ the batch, as well as return the resource in the response of this request.
 
 - `uris` *(required)*
   - An array of URIs to be checked (max length: 5000)
-- `checked_within` *(optional, defaults to 86400)*
+- `checked_within` *(optional, defaults to 14400)*
   - An integer value of the number of seconds in the past that checks for links
     are valid.
   - Use 0 to ensure links are all checked again


### PR DESCRIPTION
The `checked_within` period specifies how stale a URL check can be before the
consuming application considers it useful.  I consider the current default of
24 hours to be a bit long, and offer 4 hours as an alternative.

Local links manager (as one of the first consuming apps) needs to run a check
of all links on a nightly basis.  It is entirely possible that a check from
night to night will run a few seconds earlier and thus get no fresh check
results.

I'm aware that this value is overridable, but I guess that the use case of
doing a nightly run is likely to be a common one (or perhaps even the default),
so we should allow this to occur without friction for the user.

The other common use case is to do another run within the working day.  Local
government websites are sometimes off-line overnight for maintenance.  Doing
another run during the day so that we can get a better set of results
(especially if the site is slow to start after a service recycle or a period
of no requests) is also something that we'd want to do.  4 hours would allow this
 to occur twice within the work day without further configuration.