### PR TITLE
Reduce queue ratio

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -3,7 +3,7 @@
 :logfile: ./log/sidekiq.json.log
 :queues:
   - [webhooks, 1]
-  - [default, 20]  # remove this ratio when LLM is using a low priority queue and can cope with lots of requests
+  - [default, 10]  # remove this ratio when LLM is using a low priority queue and can cope with lots of requests
   - checks_low
 :schedule:
   cleanup:


### PR DESCRIPTION
We have a problem at the moment where the webhook queue is
getting too big and filling up memory in Redis.