### PR TITLE
Enable unique jobs for webhook workers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem "faraday", "~> 0.11"
 
 gem "govuk_sidekiq", "~> 1.0"
 gem "sidekiq-scheduler", "~> 2.1"
+gem "sidekiq-unique-jobs", "~> 5.0"
 
 gem "activerecord-import", "~> 0.17"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -263,6 +263,9 @@ GEM
       activesupport
       sidekiq (>= 2.6)
       statsd-ruby (>= 1.1.0)
+    sidekiq-unique-jobs (5.0.8)
+      sidekiq (>= 4.0, <= 6.0)
+      thor (~> 0)
     simplecov (0.14.1)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
@@ -333,6 +336,7 @@ DEPENDENCIES
   rspec-rails (~> 3.4)
   rspec-sidekiq (~> 3.0)
   sidekiq-scheduler (~> 2.1)
+  sidekiq-unique-jobs (~> 5.0)
   simplecov (~> 0.11)
   simplecov-rcov (~> 0.2)
   sqlite3

--- a/app/workers/webhook_worker.rb
+++ b/app/workers/webhook_worker.rb
@@ -4,7 +4,11 @@ end
 class WebhookWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: :webhooks, retry: 4
+  sidekiq_options queue: :webhooks, retry: 4, unique: :until_and_while_executing, unique_args: :unique_args
+
+  def self.unique_args(args)
+    [args[3]] # batch_id
+  end
 
   sidekiq_retry_in do |count|
     # retry between 15-20 minutes first, then 30-40 minutes next, then 45-60 minutes next, etc


### PR DESCRIPTION
Due to the way the link checker works at the moment (checking
'checks' rather than links), we have a situation where multiple
duplicate web hook workers can be added to the queue.

[Trello Card](https://trello.com/c/z3C7nySe/976-only-add-web-hooks-to-the-queue-when-not-already-there)