### PR TITLE
Correct development db name

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -6,7 +6,7 @@ default: &default
 
 development:
   <<: *default
-  database: link_checker_development
+  database: link_checker_api_development
   url: <%= ENV["DATABASE_URL"]%>
 
 test:


### PR DESCRIPTION
Data replication creates a db called link_checker_api_development not link_checker_development