### PR TITLE
Implement HistoricalLinkChecker

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ group :development, :test do
   gem "timecop"
   gem "webmock"
   gem "rspec-rails", "~> 3.4"
+  gem "rspec-its"
   gem "byebug" # Comes standard with Rails
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -217,6 +217,9 @@ GEM
     rspec-expectations (3.6.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.6.0)
+    rspec-its (1.0.1)
+      rspec-core (>= 2.99.0.beta1)
+      rspec-expectations (>= 2.99.0.beta1)
     rspec-mocks (3.6.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.6.0)
@@ -336,6 +339,7 @@ DEPENDENCIES
   plek (~> 1.12)
   pry
   rails (= 5.0.2)
+  rspec-its
   rspec-rails (~> 3.4)
   rspec-sidekiq (~> 3.0)
   sidekiq-scheduler (~> 2.1)
@@ -349,4 +353,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.14.5
+   1.15.1

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -129,3 +129,7 @@ en:
     redirect: This redirects to an invalid link.
 
   check_correct_manually: Check this are correct manually.
+
+  recurring_error: "Recurring %{problem}"
+  recurred_for_more_than_three_days: "This problem has been occurring for more than 3 days. %{problem_message}"
+  recurred_for_more_than_one_week: "This problem has been occurring for more than a week. %{problem_message}"

--- a/lib/historical_link_checker.rb
+++ b/lib/historical_link_checker.rb
@@ -1,0 +1,77 @@
+class HistoricalLinkChecker
+  attr_reader :report
+
+  def initialize(uri, checks)
+    @uri = uri
+    @checks = sorted_checks(checks)
+    @report = LinkChecker::UriChecker::Report.new
+  end
+
+  def call
+    current_report = LinkChecker.new(uri).call
+
+    if needs_historical_data_check?(current_report)
+      check_history(current_report)
+    else
+      current_report
+    end
+  end
+
+private
+
+  attr_reader :uri, :checks
+
+  def check_history(current_report)
+    if all_checks_have_errors?(checks_since(7.days.ago))
+      current_report.add_problem(
+        recurred_for_more_than_one_week_error(current_report)
+      )
+    elsif all_checks_have_errors?(checks_since(4.days.ago))
+      current_report.add_problem(
+        recurred_for_more_than_three_days_error(current_report)
+      )
+    else
+      current_report
+    end
+  end
+
+  def needs_historical_data_check?(current_report)
+    return false unless current_report.has_errors?
+    return false if checks.empty?
+    return false unless checks_have_errors?(checks)
+
+    true
+  end
+
+  def locale_interpolation_args(current_report)
+    { problem: current_report.problem_summary, problem_message: current_report.errors.try(:first) }
+  end
+
+  def recurred_for_more_than_one_week_error(current_report)
+    HistoricalLinkChecker::Error::RecurredForMoreThanOneWeekLinkError.new(locale_interpolation_args(current_report))
+  end
+
+  def recurred_for_more_than_three_days_error(current_report)
+    HistoricalLinkChecker::Error::RecurredForMoreThanThreeDaysLinkError.new(locale_interpolation_args(current_report))
+  end
+
+  def sorted_checks(checks)
+    checks.sort_by { |check| -1 * check.completed_at.to_i }
+  end
+
+  def checks_since(date)
+    checks.select { |check| check.completed_at > date }
+  end
+
+  def checks_have_errors?(checks_to_check)
+    checks_to_check.select { |check| check_has_error?(check) }.any?
+  end
+
+  def all_checks_have_errors?(checks_to_check)
+    checks_to_check.map { |check| check_has_error?(check) }.uniq.size == 1
+  end
+
+  def check_has_error?(check)
+    check.link_errors.any?
+  end
+end

--- a/lib/historical_link_checker/error/recurred_for_more_than_one_week_link_error.rb
+++ b/lib/historical_link_checker/error/recurred_for_more_than_one_week_link_error.rb
@@ -1,0 +1,12 @@
+module HistoricalLinkChecker::Error
+  class RecurredForMoreThanOneWeekLinkError < ::LinkChecker::UriChecker::Error
+    def initialize(options = {})
+      super(
+        from_redirect: false,
+        summary: :recurring_error,
+        message: :recurred_for_more_than_one_week,
+        **options
+      )
+    end
+  end
+end

--- a/lib/historical_link_checker/error/recurred_for_more_than_three_days_link_error.rb
+++ b/lib/historical_link_checker/error/recurred_for_more_than_three_days_link_error.rb
@@ -1,0 +1,12 @@
+module HistoricalLinkChecker::Error
+  class RecurredForMoreThanThreeDaysLinkError < ::LinkChecker::UriChecker::Error
+    def initialize(options = {})
+      super(
+        from_redirect: false,
+        summary: :recurring_error,
+        message: :recurred_for_more_than_three_days,
+        **options
+      )
+    end
+  end
+end

--- a/lib/link_checker/uri_checker/problem.rb
+++ b/lib/link_checker/uri_checker/problem.rb
@@ -45,6 +45,8 @@ module LinkChecker::UriChecker
       :UnusualUrl,
       :NotAvailableOnline,
       :NoHost,
+      :RecurredForMoreThanOneWeekLinkError,
+      :RecurredForMoreThanThreeDaysLinkError,
       :FaradayError,
       :PageNotFound,
       :PageRequiresLogin,

--- a/spec/lib/historical_link_checker_spec.rb
+++ b/spec/lib/historical_link_checker_spec.rb
@@ -1,0 +1,150 @@
+require 'rails_helper'
+
+# rubocop:disable BlockLength
+RSpec.describe HistoricalLinkChecker do
+  subject { described_class.new(uri, checks).call }
+  let(:uri) { 'https://gov.uk' }
+  let(:checks) { [] }
+  let(:report) { LinkChecker::UriChecker::Report.new }
+
+  def check_without_errors(completed_at)
+    double(link_errors: [], completed_at: completed_at)
+  end
+
+  def check_with_errors(completed_at)
+    double(
+      problem_summary: I18n.t(:page_not_found),
+      link_errors: [I18n.t('page_was_not_found.singular')],
+      completed_at: completed_at
+    )
+  end
+
+  context 'when a link has never been checked before' do
+    before do
+      allow_any_instance_of(LinkChecker).to receive(:call).and_return(report)
+    end
+
+    it { is_expected.to eq(report) }
+
+    it "should pass uri to LinkChecker" do
+      expect(LinkChecker).to receive(:new).with(uri).and_call_original
+
+      subject
+    end
+
+    context 'but it has an error' do
+      let(:report) do
+        LinkChecker::UriChecker::Report.new.add_problem(TestError::PageNotFound.new(from_redirect: false))
+      end
+
+      it { is_expected.to eq(report) }
+      its(:errors) { is_expected.to be_present }
+    end
+  end
+
+  context 'when a link has never had an error' do
+    before do
+      allow_any_instance_of(LinkChecker).to receive(:call).and_return(report)
+    end
+
+    let(:checks) do
+      [
+        check_without_errors(1.day.ago),
+        check_without_errors(3.days.ago),
+        check_without_errors(5.days.ago),
+        check_without_errors(9.days.ago)
+      ]
+    end
+
+    it { is_expected.to eq(report) }
+  end
+
+  context 'when a link currently has error' do
+    let(:report) do
+      LinkChecker::UriChecker::Report.new.add_problem(
+        TestError::PageNotFound.new(from_redirect: false)
+      )
+    end
+
+    context 'but yesterdays check was ok and so was the day before' do
+      before do
+        allow_any_instance_of(LinkChecker).to receive(:call).and_return(report)
+      end
+
+      let(:checks) do
+        [
+          check_without_errors(1.day.ago),
+          check_without_errors(3.days.ago),
+          check_with_errors(5.days.ago),
+          check_with_errors(9.days.ago)
+        ]
+      end
+
+      it { is_expected.to eq(report) }
+    end
+
+    context 'but yesterdays check was ok thought the day before was not' do
+      before do
+        allow_any_instance_of(LinkChecker).to receive(:call).and_return(report)
+      end
+
+      let(:checks) do
+        [
+          check_without_errors(1.day.ago),
+          check_with_errors(3.days.ago),
+          check_without_errors(5.days.ago),
+          check_without_errors(9.days.ago)
+        ]
+      end
+
+      it { is_expected.to eq(report) }
+    end
+
+    context 'and the same error has occurred for 3 days' do
+      before do
+        allow_any_instance_of(LinkChecker).to receive(:call).and_return(report)
+      end
+
+      let(:recurring_error) { I18n.t(:recurring_error, problem: I18n.t(:page_not_found)) }
+      let(:recurring_error_message) do
+        I18n.t(:recurred_for_more_than_three_days, problem_message: I18n.t('page_was_not_found.singular'))
+      end
+
+      let(:checks) do
+        [
+          check_with_errors(1.days.ago),
+          check_with_errors(3.days.ago),
+          check_without_errors(5.days.ago),
+          check_without_errors(9.days.ago)
+        ]
+      end
+
+      its(:problem_summary) { is_expected.to eq(recurring_error) }
+      its(:errors) { is_expected.to include(recurring_error_message) }
+    end
+
+    context 'and the same error has occurred for 8 days' do
+      before do
+        allow_any_instance_of(LinkChecker).to receive(:call).and_return(report)
+      end
+
+      let(:persistent_error) { I18n.t(:recurring_error, problem: I18n.t(:page_not_found)) }
+      let(:persistent_error_message) do
+        I18n.t(:recurred_for_more_than_one_week, problem_message: I18n.t('page_was_not_found.singular'))
+      end
+
+      let(:checks) do
+        [
+          check_with_errors(1.days.ago),
+          check_with_errors(3.days.ago),
+          check_with_errors(6.days.ago),
+          check_with_errors(8.days.ago)
+        ]
+      end
+
+      its(:problem_summary) { is_expected.to eq(persistent_error) }
+      its(:errors) { is_expected.to include(persistent_error_message) }
+    end
+  end
+end
+# rubocop:enable BlockLength

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@ require "byebug"
 require "webmock/rspec"
 require "timecop"
 require "govuk_sidekiq/testing"
+require 'rspec/its'
 
 Sidekiq::Testing.fake!
 

--- a/spec/support/test_error/page_not_found.rb
+++ b/spec/support/test_error/page_not_found.rb
@@ -1,0 +1,7 @@
+module TestError
+  class PageNotFound < ::LinkChecker::UriChecker::Error
+    def initialize(options = {})
+      super(summary: :page_not_found, message: :page_was_not_found, suggested_fix: :find_content_now, **options)
+    end
+  end
+end


### PR DESCRIPTION
`HistoricalLinkChecker` wraps `LinkChecker` to look back on previous check results so that we can raise a different set of errors when a particular error has been recurring for a while.

## Why?

This will enable us to escalate and prioritise issues that have occurred for a longer period of time.

For example, in future, we can prioritise 500 or 404 errors that have been occurring for more than a week over ones that have only been happening for a day. Sometimes URLs will disappear temporarily when a website is being deployed, or error temporarily when a developer deploys a bug (whoops).