### PR TITLE
Use HistoricalLinkChecker in CheckWorker

### DIFF
--- a/app/workers/check_worker.rb
+++ b/app/workers/check_worker.rb
@@ -26,7 +26,9 @@ class CheckWorker
 
     check.update!(started_at: Time.now)
 
-    report = LinkChecker.new(check.link.uri).call
+    previous_checks = check.link.checks.reject { |c| c == check }
+
+    report = HistoricalLinkChecker.new(check.link.uri, previous_checks).call
 
     check.update!(
       link_errors: report.errors,

--- a/spec/factories/checks.rb
+++ b/spec/factories/checks.rb
@@ -4,5 +4,10 @@ FactoryGirl.define do
     completed_at nil
     link_warnings Array.new
     link_errors Array.new
+
+    trait :with_error do
+      problem_summary { I18n.t(:page_not_found) }
+      link_errors { [I18n.t('page_was_not_found.singular')] }
+    end
   end
 end


### PR DESCRIPTION
Replace LinkChecker with HistoricalLinkChecker to enable new functionality.