### PR TITLE
First pass link monitoring

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ end
 
 group :test do
   gem "rspec-sidekiq", "~> 3.0"
+  gem "rspec-its"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -217,6 +217,9 @@ GEM
     rspec-expectations (3.6.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.6.0)
+    rspec-its (1.0.1)
+      rspec-core (>= 2.99.0.beta1)
+      rspec-expectations (>= 2.99.0.beta1)
     rspec-mocks (3.6.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.6.0)
@@ -336,6 +339,7 @@ DEPENDENCIES
   plek (~> 1.12)
   pry
   rails (= 5.0.2)
+  rspec-its
   rspec-rails (~> 3.4)
   rspec-sidekiq (~> 3.0)
   sidekiq-scheduler (~> 2.1)
@@ -349,4 +353,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.14.5
+   1.15.1

--- a/app/controllers/monitor_controller.rb
+++ b/app/controllers/monitor_controller.rb
@@ -1,0 +1,19 @@
+class MonitorController < ApplicationController
+  def create
+    monitor = LinkMonitor::CreateResourceMonitor.new(links: permitted_params[:links], service: permitted_params[:service]).call
+
+    monitor.validate!
+
+    render(json: monitor_report(monitor), status: 200)
+  end
+
+private
+
+  def permitted_params
+    params.permit(:service, links: [])
+  end
+
+  def monitor_report(monitor)
+    { id: monitor.id }
+  end
+end

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -1,5 +1,6 @@
 class Link < ApplicationRecord
   has_many :checks
+  has_one :monitor_link
 
   validates_presence_of :uri
 

--- a/app/models/monitor_link.rb
+++ b/app/models/monitor_link.rb
@@ -1,0 +1,25 @@
+class MonitorLink < ApplicationRecord
+  belongs_to :resource_monitor
+  belongs_to :link
+
+  def add_errors(errors)
+    link_errors.keep_if { |link_error| errors.include?(link_error[:message]) }
+
+    errors.each { |error| add_error(error) }
+  end
+
+  def add_error(message)
+    return if link_errors.any? { |error| error[:message] == message }
+
+    link_errors << {
+      message: message,
+      started_at: DateTime.now
+    }
+
+    save
+  end
+
+  def clear_errors
+    update!(link_errors: [])
+  end
+end

--- a/app/models/resource_monitor.rb
+++ b/app/models/resource_monitor.rb
@@ -1,0 +1,6 @@
+class ResourceMonitor < ApplicationRecord
+  validates_presence_of :service
+
+  has_many :monitor_links
+  has_many :links, through: :monitor_links
+end

--- a/app/presenters/check_presenter.rb
+++ b/app/presenters/check_presenter.rb
@@ -5,7 +5,7 @@ class CheckPresenter < SimpleDelegator
       status: status.to_s,
       checked: completed_at.try(:iso8601),
       problem_summary: problem_summary,
-      errors: link_errors,
+      errors: combined_errors,
       warnings: link_warnings,
       suggested_fix: suggested_fix,
     }

--- a/app/workers/resource_monitor_worker.rb
+++ b/app/workers/resource_monitor_worker.rb
@@ -1,0 +1,12 @@
+class ResourceMonitorWorker
+  include Sidekiq::Worker
+  include PerformAsyncInQueue
+
+  sidekiq_options retry: 3
+
+  def perform(monitor_id)
+    resource_monitor = ResourceMonitor.find(monitor_id)
+
+    LinkMonitor::CheckMonitoredLinks.new(resource_monitor: resource_monitor).call
+  end
+end

--- a/app/workers/schedule_resource_monitor_worker.rb
+++ b/app/workers/schedule_resource_monitor_worker.rb
@@ -1,0 +1,17 @@
+require "sidekiq-scheduler"
+
+class ScheduleResourceMonitorWorker
+  include Sidekiq::Worker
+
+  def perform
+    enabled_monitors.each do |monitor_id|
+      ResourceMonitorWorker.perform_async(monitor_id)
+    end
+  end
+
+private
+
+  def enabled_monitors
+    ResourceMonitor.where(enabled: true).pluck(:id)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,8 @@ Rails.application.routes.draw do
   post "/batch", to: "batch#create"
   get "/batch/:id", to: "batch#show"
 
+  post "/monitor", to: "monitor#create"
+
   if Rails.env.development?
     require "sidekiq/web"
     mount Sidekiq::Web => "/sidekiq"

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -9,3 +9,6 @@
   cleanup:
     every: 60m
     class: CleanupWorker
+  monitor:
+    cron: '0 1 * * *'
+    class: ScheduleResourceMonitorWorker

--- a/db/migrate/20171106154756_create_resource_monitors.rb
+++ b/db/migrate/20171106154756_create_resource_monitors.rb
@@ -1,0 +1,10 @@
+class CreateResourceMonitors < ActiveRecord::Migration[5.0]
+  def change
+    create_table :resource_monitors do |t|
+      t.boolean :enabled, default: true
+      t.string :service
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20171106170549_create_monitor_links.rb
+++ b/db/migrate/20171106170549_create_monitor_links.rb
@@ -1,0 +1,8 @@
+class CreateMonitorLinks < ActiveRecord::Migration[5.0]
+  def change
+    create_table :monitor_links do |t|
+      t.belongs_to :link
+      t.belongs_to :resource_monitor
+    end
+  end
+end

--- a/db/migrate/20171107160054_add_last_checked_at_to_monitor_link.rb
+++ b/db/migrate/20171107160054_add_last_checked_at_to_monitor_link.rb
@@ -1,0 +1,5 @@
+class AddLastCheckedAtToMonitorLink < ActiveRecord::Migration[5.0]
+  def change
+    add_column :monitor_links, :last_checked_at, :datetime, default: nil
+  end
+end

--- a/db/migrate/20171107162204_add_link_errors_to_monitor_link.rb
+++ b/db/migrate/20171107162204_add_link_errors_to_monitor_link.rb
@@ -1,0 +1,5 @@
+class AddLinkErrorsToMonitorLink < ActiveRecord::Migration[5.0]
+  def change
+    add_column :monitor_links, :link_errors, :json, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170713101143) do
+ActiveRecord::Schema.define(version: 20171107162204) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -48,6 +48,22 @@ ActiveRecord::Schema.define(version: 20170713101143) do
     t.string   "uri",        null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "monitor_links", force: :cascade do |t|
+    t.integer  "link_id"
+    t.integer  "resource_monitor_id"
+    t.datetime "last_checked_at"
+    t.json     "link_errors",         default: []
+    t.index ["link_id"], name: "index_monitor_links_on_link_id", using: :btree
+    t.index ["resource_monitor_id"], name: "index_monitor_links_on_resource_monitor_id", using: :btree
+  end
+
+  create_table "resource_monitors", force: :cascade do |t|
+    t.boolean  "enabled",    default: true
+    t.string   "service"
+    t.datetime "created_at",                null: false
+    t.datetime "updated_at",                null: false
   end
 
   create_table "users", force: :cascade do |t|

--- a/lib/link_monitor/check_monitored_links.rb
+++ b/lib/link_monitor/check_monitored_links.rb
@@ -1,0 +1,46 @@
+module LinkMonitor
+  class CheckMonitoredLinks
+    def initialize(resource_monitor:)
+      @resource_monitor = resource_monitor
+    end
+
+    def call
+      resource_monitor.links.includes(:checks).each { |link| check_link(link) }
+    end
+
+  private
+
+    attr_reader :resource_monitor
+
+    def check_link(link)
+      if requires_check?(link)
+        create_check(link)
+      end
+
+      update_monitor_link(link)
+    end
+
+    def update_monitor_link(link)
+      monitor_link = resource_monitor.monitor_links.find_by(link_id: link.id)
+      check = link.checks.order(completed_at: :desc).first
+
+      monitor_link.touch(:last_checked_at)
+
+      if check.link_errors.any?
+        monitor_link.add_errors(check.link_errors)
+      else
+        monitor_link.clear_errors
+      end
+    end
+
+    def requires_check?(link)
+      link.checks.none? { |check| check.completed_at > 8.hours.ago }
+    end
+
+    def create_check(link)
+      check = Check.create(link_id: link.id)
+
+      CheckWorker.run(check.id, synchronous: true)
+    end
+  end
+end

--- a/lib/link_monitor/create_resource_monitor.rb
+++ b/lib/link_monitor/create_resource_monitor.rb
@@ -1,0 +1,27 @@
+module LinkMonitor
+  class CreateResourceMonitor
+    def initialize(links:, service:)
+      @links = links
+      @service = service
+    end
+
+    def call
+      monitor = ResourceMonitor.create(service: service)
+
+      create_links(monitor) if monitor.valid?
+
+      monitor
+    end
+
+  private
+
+    attr_reader :links, :service
+
+    def create_links(monitor)
+      links.each do |link|
+        monitored_link = Link.find_or_create_by(uri: link)
+        monitor.monitor_links.find_or_create_by(link: monitored_link)
+      end
+    end
+  end
+end

--- a/spec/acceptance/checking_monitored_resources_spec.rb
+++ b/spec/acceptance/checking_monitored_resources_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+# rubocop:disable BlockLength
+RSpec.describe "Check all links for a monitored resource" do
+  let(:resource_monitor) { FactoryGirl.create(:resource_monitor, number_of_links: 1) }
+
+  let(:report) { LinkChecker::UriChecker::Report.new }
+
+  before do
+    allow_any_instance_of(LinkChecker).to receive(:call).and_return(report)
+  end
+
+  subject do
+    LinkMonitor::CheckMonitoredLinks.new(resource_monitor: resource_monitor).call
+  end
+  # rubocop:disable AmbiguousBlockAssociation
+  it 'should update last_checked_at for monitor link' do
+    expect { subject }.to change { resource_monitor.monitor_links.first.last_checked_at }
+  end
+
+  it 'should add another check to a link' do
+    expect { subject }.to change { resource_monitor.links.first.checks.count }.by(1)
+  end
+  # rubocop:enable AmbiguousBlockAssociation
+
+  context 'when another service monitors the same link' do
+    let(:other_resource_monitor) do
+      LinkMonitor::CreateResourceMonitor.new(
+        links: resource_monitor.links.map(&:uri),
+        service: "local-link-manager"
+      ).call
+    end
+
+    before do
+      LinkMonitor::CheckMonitoredLinks.new(resource_monitor: other_resource_monitor).call
+    end
+    # rubocop:disable AmbiguousBlockAssociation
+    it 'should update last_checked_at for monitor link' do
+      expect { subject }.to change { resource_monitor.monitor_links.first.last_checked_at }
+    end
+
+    it 'should not add another check to a link' do
+      expect { subject }.not_to change { resource_monitor.links.first.checks.count }
+    end
+    # rubocop:enable AmbiguousBlockAssociation
+  end
+end
+# rubocop:enable BlockLength

--- a/spec/acceptance/create_resource_monitor_spec.rb
+++ b/spec/acceptance/create_resource_monitor_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+# rubocop:disable BlockLength
+RSpec.describe "Create an enabled monitor" do
+  subject do
+    LinkMonitor::CreateResourceMonitor.new(links: links, service: service).call
+  end
+
+  let(:links) { ["http://example.com/a", "http://example.com/b"] }
+  let(:service) { "local-link-manager" }
+
+  context "without links" do
+    let(:links) { [] }
+    it { is_expected.to be_a(ResourceMonitor) }
+  end
+
+  context "with links" do
+    it { is_expected.to be_a(ResourceMonitor) }
+
+    it "should persist data" do
+      monitor = ResourceMonitor.find(subject.id)
+
+      expect(monitor.links).not_to be_empty
+      expect(monitor.monitor_links).not_to be_empty
+    end
+  end
+
+  context "when another monitor exists" do
+    before do
+      LinkMonitor::CreateResourceMonitor.new(links: links, service: "gov-uk").call
+      subject
+    end
+
+    it "does not duplicate links" do
+      expect(Link.all.count).to eq(2)
+    end
+
+    it "does create new monitor links" do
+      expect(MonitorLink.all.count).to eq(4)
+    end
+  end
+end
+# rubocop:enable BlockLength

--- a/spec/factories/checks.rb
+++ b/spec/factories/checks.rb
@@ -4,5 +4,14 @@ FactoryGirl.define do
     completed_at nil
     link_warnings Array.new
     link_errors Array.new
+
+    trait :completed do
+      started_at { 10.minutes.ago }
+      completed_at { DateTime.now }
+    end
+
+    trait :with_errors do
+      link_errors { [I18n.t(:singular, scope: :page_was_not_found)] }
+    end
   end
 end

--- a/spec/factories/monitor_links.rb
+++ b/spec/factories/monitor_links.rb
@@ -1,0 +1,10 @@
+FactoryGirl.define do
+  factory :monitor_link do
+    last_checked_at { DateTime.now }
+    link_errors Array.new
+
+    trait :with_history do
+      link_errors { [{ message: I18n.t(:singular, scope: :page_was_not_found), started_at: 1.day.ago }] }
+    end
+  end
+end

--- a/spec/factories/resource_monitor.rb
+++ b/spec/factories/resource_monitor.rb
@@ -1,0 +1,13 @@
+FactoryGirl.define do
+  factory :resource_monitor do
+    service "govuk"
+
+    transient do
+      number_of_links 3
+    end
+
+    after(:create) do |resource, evaluator|
+      resource.links << create_list(:link, evaluator.number_of_links)
+    end
+  end
+end

--- a/spec/lib/link_monitor/check_monitored_links_spec.rb
+++ b/spec/lib/link_monitor/check_monitored_links_spec.rb
@@ -1,0 +1,107 @@
+require "rails_helper"
+# rubocop:disable BlockLength
+RSpec.describe LinkMonitor::CheckMonitoredLinks do
+  let(:resource_monitor) { FactoryGirl.create(:resource_monitor, number_of_links: 1) }
+
+  subject { described_class.new(resource_monitor: resource_monitor).call }
+
+  let(:report) do
+    LinkChecker::UriChecker::Report.new.add_problem(
+      TestError::PageNotFound.new(from_redirect: false)
+    )
+  end
+
+  before do
+    allow_any_instance_of(LinkChecker).to receive(:call).and_return(report)
+  end
+
+  context 'when no checks in the last 8 hours exists' do
+    it 'should call LinkChecker' do
+      expect(LinkChecker).to receive(:new).exactly(1).times.and_call_original
+
+      subject
+    end
+
+    it 'should create a check' do
+      subject
+
+      resource_monitor.reload
+
+      expect(resource_monitor.links.first.checks.last.problem_summary).to eq(report.problem_summary)
+    end
+
+    # rubocop:disable AmbiguousBlockAssociation
+    it 'should update the monitored link' do
+      expect { subject }.to change { resource_monitor.monitor_links.first.last_checked_at }
+    end
+    # rubocop:enable AmbiguousBlockAssociation
+  end
+
+  context 'when a check exists within 8 hours' do
+    before do
+      resource_monitor.links.first.checks.create(completed_at: 30.minutes.ago)
+    end
+
+    it 'should not call LinkChecker' do
+      expect(LinkChecker).not_to receive(:new)
+
+      subject
+    end
+    # rubocop:disable AmbiguousBlockAssociation
+    it 'should not create another check' do
+      expect { subject }.not_to change { resource_monitor.links.first.checks.count }
+    end
+
+    it 'should update the monitored link' do
+      expect { subject }.to change { resource_monitor.monitor_links.first.last_checked_at }
+    end
+    # rubocop:enable AmbiguousBlockAssociation
+  end
+
+  context 'when there is an existing error' do
+    context 'and the report comes back ok' do
+      it 'should remove the error history' do
+        expect(resource_monitor.monitor_links.first.errors).to be_empty
+      end
+    end
+
+    context 'and the report comes with another error' do
+      before do
+        resource_monitor.monitor_links.first.add_error('SSL expired')
+      end
+
+      it 'should update the error history' do
+        subject
+        expect(resource_monitor.monitor_links.first.link_errors.last['message']).to include(report.errors.first)
+      end
+    end
+
+    context 'and the report comes with another error' do
+      before do
+        resource_monitor.monitor_links.first.add_error('SSL expired')
+      end
+
+      it 'should update the error history' do
+        subject
+        expect(resource_monitor.monitor_links.first.link_errors.count).to eq(1)
+        expect(resource_monitor.monitor_links.first.link_errors.last['message']).to eq(report.errors.first)
+      end
+    end
+
+    context 'and the report comes without an errors' do
+      let(:report) { LinkChecker::UriChecker::Report.new }
+
+      before do
+        allow_any_instance_of(LinkChecker).to receive(:call).and_return(report)
+        resource_monitor.monitor_links.first.add_error('SSL expired')
+      end
+
+      it 'should update the error history' do
+        subject
+        resource_monitor.reload
+        expect(resource_monitor.monitor_links.first.link_errors).to be_empty
+      end
+    end
+  end
+end
+# rubocop:enable BlockLength

--- a/spec/lib/link_monitor/create_resource_monitor_spec.rb
+++ b/spec/lib/link_monitor/create_resource_monitor_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+
+RSpec.describe LinkMonitor::CreateResourceMonitor do
+  let(:links) { [] }
+  let(:service) { 'govuk' }
+  subject { described_class.new(links: links, service: service).call }
+
+  it { is_expected.to be_a(ResourceMonitor) }
+end

--- a/spec/presenters/check_presenter_spec.rb
+++ b/spec/presenters/check_presenter_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe CheckPresenter do
+  let(:link) { FactoryGirl.create(:link) }
+  let(:check) { FactoryGirl.create(:check, :completed, link: link) }
+
+  subject { described_class.new(check).link_report }
+
+  let(:expected_link_report) do
+    {
+      checked: check.completed_at.try(:iso8601),
+      errors: [],
+      problem_summary: nil,
+      status: "ok",
+      suggested_fix: nil,
+      uri: link.uri,
+      warnings: []
+    }
+  end
+
+  it { is_expected.to eq(expected_link_report) }
+
+  context 'when the link is monitored' do
+    let(:monitor_link) { FactoryGirl.create(:monitor_link, link: link) }
+
+    it { is_expected.to eq(expected_link_report) }
+
+    context 'and when the link has a persistent error' do
+      let(:check) { FactoryGirl.create(:check, :completed, :with_errors, link: link) }
+      let!(:monitor_link) { FactoryGirl.create(:monitor_link, :with_history, link: link) }
+
+      let(:expected_message) { "#{monitor_link.link_errors.first['message']} since #{monitor_link.link_errors.first['started_at']}" }
+
+      its([:errors]) { is_expected.to include(expected_message) }
+    end
+  end
+end

--- a/spec/requests/monitor_spec.rb
+++ b/spec/requests/monitor_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+# rubocop:disable BlockLength
+RSpec.describe "monitor path", type: :request do
+  shared_examples "returns a report" do
+    it "returns 200" do
+      expect(response).to have_http_status(200)
+    end
+
+    it "returns a monitor report" do
+      json = JSON.parse(response.body)
+
+      expect(json).to match("id" => ResourceMonitor.last.id)
+    end
+  end
+
+  describe "POST /monitor" do
+    let(:params) do
+      {
+        links: ["https://example.com/a", "https://example.com/b"],
+        service: "govuk"
+      }
+    end
+
+    context 'when valid' do
+      before do
+        post "/monitor", params: params.to_json, headers: { "Content-Type" => "application/json" }
+      end
+
+      include_examples "returns a report"
+    end
+
+    context 'when invalid' do
+      subject do
+        post "/monitor", params: params.to_json, headers: { "Content-Type" => "application/json" }
+      end
+
+      let(:params) do
+        {
+          links: ["https://example.com/a", "https://example.com/b"],
+          service: nil
+        }
+      end
+
+      it "returns an error" do
+        expect { subject }.to raise_error(ActiveRecord::RecordInvalid)
+      end
+    end
+  end
+end
+# rubocop:enable BlockLength

--- a/spec/support/test_error/page_not_found.rb
+++ b/spec/support/test_error/page_not_found.rb
@@ -1,0 +1,7 @@
+module TestError
+  class PageNotFound < ::LinkChecker::UriChecker::Error
+    def initialize(options = {})
+      super(summary: :page_not_found, message: :page_was_not_found, suggested_fix: :find_content_now, **options)
+    end
+  end
+end


### PR DESCRIPTION
This PR introduces:

- A new `POST` endpoint to create new monitored resources, which is a collection of links that lives within another service. e.g. Whitehall. When a monitored resource is created, it also creates a joining entity - `MonitorLink` - where we store a history of link errors. This history is buildup from the results of the existing checks.

- New workers that monitor the links associated with monitored resources. `ScheduleResourceMonitorWorker` is scheduled to run at 1 am every day [i.e. a quiet period] to queue up `ResourceMonitorWorker`'s which call `LinkMonitor::UseCase::CheckMonitoredLinks` for each enabled resource monitor.

- In order to see the result of this, we are temporarily decorating the link_report with the dates on which the error first started to appear.