### PR TITLE
Add organisation tags to resource monitor

### DIFF
--- a/app/controllers/monitor_controller.rb
+++ b/app/controllers/monitor_controller.rb
@@ -2,7 +2,8 @@ class MonitorController < ApplicationController
   def create
     monitor = LinkMonitor::UpsertResourceMonitor.new(
       links: permitted_params[:links],
-      app: permitted_params[:app], reference: permitted_params[:reference]
+      app: permitted_params[:app], reference: permitted_params[:reference],
+      organisation: permitted_params[:organisation]
     ).call
 
     monitor.validate!
@@ -13,7 +14,7 @@ class MonitorController < ApplicationController
 private
 
   def permitted_params
-    params.permit(:app, :reference, links: [])
+    params.permit(:organisation, :app, :reference, links: [])
   end
 
   def monitor_report(monitor)

--- a/db/migrate/20171116154948_add_organisation_to_resource_monitor.rb
+++ b/db/migrate/20171116154948_add_organisation_to_resource_monitor.rb
@@ -1,0 +1,5 @@
+class AddOrganisationToResourceMonitor < ActiveRecord::Migration[5.0]
+  def change
+    add_column :resource_monitors, :organisation, :string, default: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171115131344) do
+ActiveRecord::Schema.define(version: 20171116154948) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -60,11 +60,12 @@ ActiveRecord::Schema.define(version: 20171115131344) do
   end
 
   create_table "resource_monitors", force: :cascade do |t|
-    t.boolean  "enabled",    default: true, null: false
-    t.datetime "created_at",                null: false
-    t.datetime "updated_at",                null: false
-    t.string   "app",                       null: false
-    t.string   "reference",                 null: false
+    t.boolean  "enabled",      default: true, null: false
+    t.datetime "created_at",                  null: false
+    t.datetime "updated_at",                  null: false
+    t.string   "app",                         null: false
+    t.string   "reference",                   null: false
+    t.string   "organisation"
   end
 
   create_table "users", force: :cascade do |t|

--- a/lib/link_monitor/upsert_resource_monitor.rb
+++ b/lib/link_monitor/upsert_resource_monitor.rb
@@ -1,14 +1,15 @@
 module LinkMonitor
   class UpsertResourceMonitor
-    def initialize(links:, app:, reference:)
+    def initialize(links:, app:, reference:, organisation: nil)
       @links = links
       @app = app
       @reference = reference
+      @organisation = organisation
     end
 
     def call
       monitor = ResourceMonitor.find_or_create_by(app: app, reference: reference)
-
+      monitor.update(organisation: organisation)
       manage_links(monitor) if monitor.valid?
 
       monitor
@@ -16,7 +17,7 @@ module LinkMonitor
 
   private
 
-    attr_reader :links, :app, :reference
+    attr_reader :links, :app, :reference, :organisation
 
     def create_links(monitor)
       links.each do |link|

--- a/spec/acceptance/upserting_resource_monitor_spec.rb
+++ b/spec/acceptance/upserting_resource_monitor_spec.rb
@@ -76,5 +76,33 @@ RSpec.describe "Create an enabled monitor" do
       expect(resource.links.first.id).not_to eq(out_of_use_link.id)
     end
   end
+
+  context "when we supply an organisation" do
+    subject do
+      LinkMonitor::UpsertResourceMonitor.new(
+        links: links,
+        app: service,
+        reference: "Text:1",
+        organisation: "testorg"
+      ).call
+    end
+
+    its(:organisation) { is_expected.to eq("testorg") }
+  end
+
+  context "when we update the organisation" do
+    let!(:resource_monitor) { FactoryGirl.create(:resource_monitor, organisation: 'testorg2') }
+
+    subject do
+      LinkMonitor::UpsertResourceMonitor.new(
+        links: links,
+        app: resource_monitor.app,
+        reference: resource_monitor.reference,
+        organisation: "test_org"
+      ).call
+    end
+
+    its(:organisation) { is_expected.to eq("test_org") }
+  end
 end
 # rubocop:enable BlockLength

--- a/spec/models/resource_monitor_spec.rb
+++ b/spec/models/resource_monitor_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ResourceMonitor, type: :model do
     end
 
     subject do
-      ResourceMonitor.create(reference: resource_monitor.reference, app: "govuk")
+      ResourceMonitor.create(reference: resource_monitor.reference, app: "govuk", organisation: "Testorganisation")
     end
 
     it "validates the uniqueness of resource id and type" do

--- a/spec/requests/monitor_spec.rb
+++ b/spec/requests/monitor_spec.rb
@@ -14,23 +14,29 @@ RSpec.describe "monitor path", type: :request do
   end
 
   describe "POST /monitor" do
+    let(:organisation) { "testorg" }
     let(:params) do
       {
         links: ["https://example.com/a", "https://example.com/b"],
         app: "govuk",
-        reference: "test:1"
+        reference: "test:1",
+        organisation: organisation
       }
     end
 
-    context 'when valid' do
+    context "when valid" do
       before do
         post "/monitor", params: params.to_json, headers: { "Content-Type" => "application/json" }
       end
 
       include_examples "returns a report"
+
+      it "should create a ResourceMonitor with a organisation" do
+        expect(ResourceMonitor.last.organisation).to eq(organisation)
+      end
     end
 
-    context 'when invalid' do
+    context "when invalid" do
       subject do
         post "/monitor", params: params.to_json, headers: { "Content-Type" => "application/json" }
       end


### PR DESCRIPTION
Organisation tags have been added so we can find the history of link errors by an organisation