### PR TITLE
Add link history

### DIFF
--- a/app/models/check.rb
+++ b/app/models/check.rb
@@ -55,7 +55,7 @@ class Check < ApplicationRecord
   end
 
   def combined_errors
-    if link.monitor_links.any?
+    if link&.link_history&.link_errors.present?
       combine_link_history
     else
       link_errors
@@ -65,7 +65,7 @@ class Check < ApplicationRecord
 private
 
   def build_error_message(error)
-    error_history = link.monitor_links.first.link_errors.select { |link_error| link_error['message'] == error }
+    error_history = link.link_history.link_errors.select { |link_error| link_error['message'] == error }
 
     if error_history.any?
       "#{error_history[0]['message']} since #{error_history[0]['started_at']}"

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -1,6 +1,7 @@
 class Link < ApplicationRecord
   has_many :checks
   has_many :monitor_links
+  has_one :link_history
 
   validates_presence_of :uri
 

--- a/app/models/link_history.rb
+++ b/app/models/link_history.rb
@@ -1,0 +1,34 @@
+class LinkHistory < ApplicationRecord
+  belongs_to :link
+
+  #To do: store link warnings
+  def update_errors(errors)
+    remove_resolved_errors(errors)
+    errors.each { |error| add_error(error) }
+  end
+
+  def add_error(message)
+    return if error_exists?(message)
+
+    link_errors << {
+      message: message,
+      started_at: DateTime.now
+    }
+
+    save
+  end
+
+  def clear_errors
+    update!(link_errors: [])
+  end
+
+private
+
+  def remove_resolved_errors(errors)
+    link_errors.keep_if { |link_error| errors.include?(link_error[:message]) }
+  end
+
+  def error_exists?(message)
+    link_errors.any? { |error| error[:message] == message }
+  end
+end

--- a/app/models/monitor_link.rb
+++ b/app/models/monitor_link.rb
@@ -1,25 +1,4 @@
 class MonitorLink < ApplicationRecord
   belongs_to :resource_monitor
   belongs_to :link
-
-  def add_errors(errors)
-    link_errors.keep_if { |link_error| errors.include?(link_error[:message]) }
-
-    errors.each { |error| add_error(error) }
-  end
-
-  def add_error(message)
-    return if link_errors.any? { |error| error[:message] == message }
-
-    link_errors << {
-      message: message,
-      started_at: DateTime.now
-    }
-
-    save
-  end
-
-  def clear_errors
-    update!(link_errors: [])
-  end
 end

--- a/db/migrate/20171121110841_create_link_histories.rb
+++ b/db/migrate/20171121110841_create_link_histories.rb
@@ -1,0 +1,10 @@
+class CreateLinkHistories < ActiveRecord::Migration[5.0]
+  def change
+    create_table :link_histories do |t|
+      t.json :link_errors, default: [], null: false
+      t.references :link, index: true, foreign_key: true, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20171121113257_migrate_data_from_monitor_link_to_link_history.rb
+++ b/db/migrate/20171121113257_migrate_data_from_monitor_link_to_link_history.rb
@@ -1,0 +1,10 @@
+class MigrateDataFromMonitorLinkToLinkHistory < ActiveRecord::Migration[5.0]
+  def change
+    MonitorLink.find_each do |link|
+      LinkHistory.create(
+        link_id: link.id,
+        link_errors: link.link_errors
+      )
+    end
+  end
+end

--- a/db/migrate/20171121120032_remove_link_errors_from_monitor_links.rb
+++ b/db/migrate/20171121120032_remove_link_errors_from_monitor_links.rb
@@ -1,0 +1,5 @@
+class RemoveLinkErrorsFromMonitorLinks < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :monitor_links, :link_errors, :json
+  end
+end

--- a/db/migrate/20171123105000_remove_last_checked_at_from_monitor_links.rb
+++ b/db/migrate/20171123105000_remove_last_checked_at_from_monitor_links.rb
@@ -1,0 +1,5 @@
+class RemoveLastCheckedAtFromMonitorLinks < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :monitor_links, :last_checked_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171121110841) do
+ActiveRecord::Schema.define(version: 20171121113257) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171121120032) do
+ActiveRecord::Schema.define(version: 20171123105000) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -59,9 +59,8 @@ ActiveRecord::Schema.define(version: 20171121120032) do
   end
 
   create_table "monitor_links", force: :cascade do |t|
-    t.integer  "link_id"
-    t.integer  "resource_monitor_id"
-    t.datetime "last_checked_at"
+    t.integer "link_id"
+    t.integer "resource_monitor_id"
     t.index ["link_id"], name: "index_monitor_links_on_link_id", using: :btree
     t.index ["resource_monitor_id"], name: "index_monitor_links_on_resource_monitor_id", using: :btree
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171115131344) do
+ActiveRecord::Schema.define(version: 20171121110841) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,6 +44,14 @@ ActiveRecord::Schema.define(version: 20171115131344) do
     t.index ["link_id"], name: "index_checks_on_link_id", using: :btree
   end
 
+  create_table "link_histories", force: :cascade do |t|
+    t.json     "link_errors", default: [], null: false
+    t.integer  "link_id",                  null: false
+    t.datetime "created_at",               null: false
+    t.datetime "updated_at",               null: false
+    t.index ["link_id"], name: "index_link_histories_on_link_id", using: :btree
+  end
+
   create_table "links", force: :cascade do |t|
     t.string   "uri",        null: false
     t.datetime "created_at", null: false
@@ -54,7 +62,7 @@ ActiveRecord::Schema.define(version: 20171115131344) do
     t.integer  "link_id"
     t.integer  "resource_monitor_id"
     t.datetime "last_checked_at"
-    t.json     "link_errors",         default: []
+    t.json     "link_errors"
     t.index ["link_id"], name: "index_monitor_links_on_link_id", using: :btree
     t.index ["resource_monitor_id"], name: "index_monitor_links_on_resource_monitor_id", using: :btree
   end
@@ -84,4 +92,5 @@ ActiveRecord::Schema.define(version: 20171115131344) do
   add_foreign_key "batch_checks", "batches", on_delete: :cascade
   add_foreign_key "batch_checks", "checks"
   add_foreign_key "checks", "links"
+  add_foreign_key "link_histories", "links"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171121113257) do
+ActiveRecord::Schema.define(version: 20171121120032) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -62,7 +62,6 @@ ActiveRecord::Schema.define(version: 20171121113257) do
     t.integer  "link_id"
     t.integer  "resource_monitor_id"
     t.datetime "last_checked_at"
-    t.json     "link_errors"
     t.index ["link_id"], name: "index_monitor_links_on_link_id", using: :btree
     t.index ["resource_monitor_id"], name: "index_monitor_links_on_resource_monitor_id", using: :btree
   end

--- a/lib/link_monitor/check_monitored_links.rb
+++ b/lib/link_monitor/check_monitored_links.rb
@@ -5,7 +5,7 @@ module LinkMonitor
     end
 
     def call
-      resource_monitor.links.includes(:checks).each { |link| check_link(link) }
+      resource_monitor.links.includes(:checks, :link_history).each { |link| check_link(link) }
     end
 
   private
@@ -17,19 +17,17 @@ module LinkMonitor
         create_check(link)
       end
 
-      update_monitor_link(link)
+      update_link_history(link)
     end
 
-    def update_monitor_link(link)
-      monitor_link = resource_monitor.monitor_links.find_by(link_id: link.id)
+    def update_link_history(link)
+      link_history = link.link_history ||= link.create_link_history
       check = link.checks.order(completed_at: :desc).first
 
-      monitor_link.touch(:last_checked_at)
-
       if check.link_errors.any?
-        monitor_link.add_errors(check.link_errors)
+        link_history.update_errors(check.link_errors)
       else
-        monitor_link.clear_errors
+        link_history.clear_errors
       end
     end
 

--- a/spec/factories/link_histories.rb
+++ b/spec/factories/link_histories.rb
@@ -1,7 +1,10 @@
 FactoryGirl.define do
-  factory :monitor_link do
-    last_checked_at { DateTime.now }
+  factory :link_history do
     link_errors Array.new
+
+    trait :with_link do
+      association :link
+    end
 
     trait :with_history do
       link_errors { [{ message: I18n.t(:singular, scope: :page_was_not_found), started_at: 1.day.ago }] }

--- a/spec/factories/links.rb
+++ b/spec/factories/links.rb
@@ -1,5 +1,11 @@
 FactoryGirl.define do
   factory :link do
     uri "https://www.gov.uk"
+
+    trait :with_history do
+      after(:create) do |link|
+        create(:link_history, link_id: link.id)
+      end
+    end
   end
 end

--- a/spec/factories/resource_monitor.rb
+++ b/spec/factories/resource_monitor.rb
@@ -8,7 +8,7 @@ FactoryGirl.define do
     end
 
     after(:create) do |resource, evaluator|
-      resource.links << create_list(:link, evaluator.number_of_links)
+      resource.links << create_list(:link, evaluator.number_of_links, :with_history)
     end
   end
 end

--- a/spec/lib/link_monitor/check_monitored_links_spec.rb
+++ b/spec/lib/link_monitor/check_monitored_links_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe LinkMonitor::CheckMonitoredLinks do
 
     # rubocop:disable AmbiguousBlockAssociation
     it 'should update the monitored link' do
-      expect { subject }.to change { resource_monitor.monitor_links.first.last_checked_at }
+      expect { subject }.to change { resource_monitor.links.first.link_history.updated_at }
     end
     # rubocop:enable AmbiguousBlockAssociation
   end
@@ -52,8 +52,8 @@ RSpec.describe LinkMonitor::CheckMonitoredLinks do
       expect { subject }.not_to change { resource_monitor.links.first.checks.count }
     end
 
-    it 'should update the monitored link' do
-      expect { subject }.to change { resource_monitor.monitor_links.first.last_checked_at }
+    it 'should not update the link_history' do
+      expect { subject }.not_to change { resource_monitor.links.first.link_history.updated_at }
     end
     # rubocop:enable AmbiguousBlockAssociation
   end
@@ -61,30 +61,30 @@ RSpec.describe LinkMonitor::CheckMonitoredLinks do
   context 'when there is an existing error' do
     context 'and the report comes back ok' do
       it 'should remove the error history' do
-        expect(resource_monitor.monitor_links.first.errors).to be_empty
+        expect(resource_monitor.links.first.link_history.link_errors).to be_empty
       end
     end
 
     context 'and the report comes with another error' do
       before do
-        resource_monitor.monitor_links.first.add_error('SSL expired')
+        resource_monitor.links.first.link_history.add_error('SSL expired')
       end
 
       it 'should update the error history' do
         subject
-        expect(resource_monitor.monitor_links.first.link_errors.last['message']).to include(report.errors.first)
+        expect(resource_monitor.links.first.link_history.link_errors.last['message']).to include(report.errors.first)
       end
     end
 
     context 'and the report comes with another error' do
       before do
-        resource_monitor.monitor_links.first.add_error('SSL expired')
+        resource_monitor.links.first.link_history.add_error('SSL expired')
       end
 
       it 'should update the error history' do
         subject
-        expect(resource_monitor.monitor_links.first.link_errors.count).to eq(1)
-        expect(resource_monitor.monitor_links.first.link_errors.last['message']).to eq(report.errors.first)
+        expect(resource_monitor.links.first.link_history.link_errors.count).to eq(1)
+        expect(resource_monitor.links.first.link_history.link_errors.last['message']).to eq(report.errors.first)
       end
     end
 
@@ -93,13 +93,13 @@ RSpec.describe LinkMonitor::CheckMonitoredLinks do
 
       before do
         allow_any_instance_of(LinkChecker).to receive(:call).and_return(report)
-        resource_monitor.monitor_links.first.add_error('SSL expired')
+        resource_monitor.links.first.link_history.add_error('SSL expired')
       end
 
       it 'should update the error history' do
         subject
         resource_monitor.reload
-        expect(resource_monitor.monitor_links.first.link_errors).to be_empty
+        expect(resource_monitor.links.first.link_history.link_errors).to be_empty
       end
     end
   end

--- a/spec/models/link_history_spec.rb
+++ b/spec/models/link_history_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe LinkHistory, type: :model do
+  describe "#update_errors" do
+    let(:link_history) { FactoryGirl.create(:link_history, :with_link) }
+    let(:errors) do
+      ["an error"]
+    end
+
+    before do
+      link_history.update_errors(errors)
+    end
+
+    it "does not add the same error twice" do
+      link_history.update_errors(errors)
+      expect(link_history.link_errors.count).to eq(1)
+    end
+  end
+end

--- a/spec/presenters/check_presenter_spec.rb
+++ b/spec/presenters/check_presenter_spec.rb
@@ -20,9 +20,9 @@ RSpec.describe CheckPresenter do
 
   it { is_expected.to eq(expected_link_report) }
 
-  context 'when the link has a monitored link but no historical checks yet' do
+  context 'when the link has a history but no historical checks yet' do
     let(:check) { FactoryGirl.create(:check, :completed, :with_errors, link: link) }
-    let!(:monitor_link) { FactoryGirl.create(:monitor_link, link: link) }
+    let!(:link_history) { FactoryGirl.create(:link_history, link: link) }
 
     let(:expected_message) { check.link_errors.first }
 
@@ -36,9 +36,9 @@ RSpec.describe CheckPresenter do
 
     context 'and when the link has a persistent error' do
       let(:check) { FactoryGirl.create(:check, :completed, :with_errors, link: link) }
-      let!(:monitor_link) { FactoryGirl.create(:monitor_link, :with_history, link: link) }
+      let!(:link_history) { FactoryGirl.create(:link_history, :with_history, link: link) }
 
-      let(:expected_message) { "#{monitor_link.link_errors.first['message']} since #{monitor_link.link_errors.first['started_at']}" }
+      let(:expected_message) { "#{link_history.link_errors.first['message']} since #{link_history.link_errors.first['started_at']}" }
 
       its([:errors]) { is_expected.to include(expected_message) }
     end


### PR DESCRIPTION
Added link history table - to store error histories for each link. Migration to add the link_histories table, migration to copy data from monitor links to link_histories and migration to delete link errors from monitor_links