### PR TITLE
Change links uri column

### DIFF
--- a/db/migrate/20171206130707_change_uri_column_on_links.rb
+++ b/db/migrate/20171206130707_change_uri_column_on_links.rb
@@ -1,0 +1,9 @@
+class ChangeUriColumnOnLinks < ActiveRecord::Migration[5.0]
+  def up
+    change_column :links, :uri, :text, null: false
+  end
+
+  def down
+    change_column :links, :uri, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171123105000) do
+ActiveRecord::Schema.define(version: 20171206130707) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -53,7 +53,7 @@ ActiveRecord::Schema.define(version: 20171123105000) do
   end
 
   create_table "links", force: :cascade do |t|
-    t.string   "uri",        null: false
+    t.text     "uri",        null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end


### PR DESCRIPTION
Mimicking the change in alphagov/whitehall#3581 in link checker api

There are some instances of some _really_ long links within whitehall e.g.

```md
https://online.businesslink.gov.uk/hub/action/render?pageId=mynewbusiness&furlname=mynewbusiness&furlparam=mynewbusiness&ref=http%3A//www.businesslink.gov.uk/bdotg/action/detail%3FitemId%3D1097188312%26type%3DCAMPAIGN%26furlname%3Dnewservices%26furlparam%3Dnewservices%26ref%3D%26domain%3Dwww.businesslink.gov.uk&domain=www.businesslink.gov.uk
```

To accomodate these links we need to change the column type.