### PR TITLE
Enable cookies to avoid infinite redirect loops

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem "pg"
 gem "govuk_app_config", "~> 0.2"
 
 gem "faraday", "~> 0.11"
+gem "faraday-cookie_jar", "~>0.0.6"
 
 gem "govuk_sidekiq", "~> 2.0"
 gem "sidekiq-scheduler", "~> 2.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,6 +72,9 @@ GEM
       railties (>= 3.0.0)
     faraday (0.12.2)
       multipart-post (>= 1.2, < 3)
+    faraday-cookie_jar (0.0.6)
+      faraday (>= 0.7.4)
+      http-cookie (~> 1.0.0)
     ffi (1.9.18)
     gds-api-adapters (47.9.1)
       link_header
@@ -329,6 +332,7 @@ DEPENDENCIES
   deprecated_columns
   factory_girl_rails (~> 4.7)
   faraday (~> 0.11)
+  faraday-cookie_jar (~> 0.0.6)
   gds-sso (~> 13.0)
   govuk-lint
   govuk_app_config (~> 0.2)
@@ -353,4 +357,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.15.1
+   1.16.0

--- a/lib/link_checker/uri_checker/http_checker.rb
+++ b/lib/link_checker/uri_checker/http_checker.rb
@@ -90,6 +90,12 @@ module LinkChecker::UriChecker
   end
 
   class HttpChecker < Checker
+    def self.connection
+      @connection ||= Faraday.new(headers: { accept_encoding: "none" }) do |faraday|
+        faraday.adapter Faraday.default_adapter
+      end
+    end
+
     def call
       if uri.host.nil?
         return add_problem(NoHost.new(from_redirect: from_redirect?))
@@ -267,15 +273,9 @@ module LinkChecker::UriChecker
     end
 
     def run_connection_request(method)
-      connection.run_request(method, uri, nil, nil) do |request|
+      self.class.connection.run_request(method, uri, nil, nil) do |request|
         request.options[:timeout] = RESPONSE_TIME_LIMIT
         request.options[:open_timeout] = RESPONSE_TIME_LIMIT
-      end
-    end
-
-    def connection
-      @connection ||= Faraday.new(headers: { accept_encoding: "none" }) do |faraday|
-        faraday.adapter Faraday.default_adapter
       end
     end
   end


### PR DESCRIPTION
This change adds cookies to Faraday to avoid false positives being raised by HttpChecker. False positives were occuring because some web pages redirect to themselves if no cookies are present. Because we never store cookies whilst checking, the check raises it as a redirect loop error incorrectly.

Reproduce the issue with cURL:

```
curl -I -L 'https://sharedsystems.eu-supply.com/login.asp?B=SELLAFIELD'
```

Fix the issue with cURL:

```
curl --cookies -I -L 'https://sharedsystems.eu-supply.com/login.asp?B=SELLAFIELD'
```

We move the initialisation of the Faraday connection object into a class level singleton so the cookie jar can be shared. Cookie jar sharing needs to occur across instances of the class because a new instance of HttpChecker is created for each redirect.

## Lack of tests

We can create a test that replicates this issue if we disable Webmock. Unfortunately the issue cannot be recreated with Webmock and therefore we haven't got a test with this change.

Any thoughts on how we can test it?