### PR TITLE
Fix redirect loop caused by lack of redirect leeway

### DIFF
--- a/lib/link_checker/uri_checker/http_checker.rb
+++ b/lib/link_checker/uri_checker/http_checker.rb
@@ -126,7 +126,7 @@ module LinkChecker::UriChecker
     INVALID_TOP_LEVEL_DOMAINS = %w(xxx adult dating porn sex sexy singles).freeze
     REDIRECT_STATUS_CODES = [301, 302, 303, 307, 308].freeze
     REDIRECT_LIMIT = 8
-    REDIRECT_LOOP_LIMIT = 2
+    REDIRECT_LOOP_LIMIT = 5
     REDIRECT_WARNING = 2
     RESPONSE_TIME_LIMIT = 15
     RESPONSE_TIME_WARNING = 5


### PR DESCRIPTION
Some websites require multiple refreshes to the same page to generate cookies required for page viewing. This fix increases the number of page redirects allowed to ensure that all cookies can be generated to view the page. Redirect limit set to 5.