### PR TITLE
Add rate limit token header to request to gov.uk

### DIFF
--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -13,13 +13,17 @@
 development:
   secret_key_base: 36746f0eb3c57b16be0278bdf9a9418ec225ecd5f9a3183697a3dc0dfd3aa1d05d285b3ed42b77c92ae6deee7af6a2b9bc87f119eca9c74810dcc43ddd5eb02b
   google_api_key: <%= ENV["GOOGLE_API_KEY"] %>
+  rate_limit_token: pfB6uNKYC8sB9PVgBLdwFToN
 
 test:
   secret_key_base: b81a573d7703bfdf5c80f2a201c9e9d7ec5aad3326e252534568e1a82a7fc79a09f0d8ebd5e7e0fb5fc584f6a23440f2be5c986ec723df389ef7527e3e7ffc12
   google_api_key: test
+  rate_limit_token: pfB6uNKYC8sB9PVgBLdwFToN
+
 
 # Do not keep production secrets in the repository,
 # instead read values from the environment.
 production:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
   google_api_key: <%= ENV["GOOGLE_API_KEY"] %>
+  rate_limit_token: <%= ENV["RATE_LIMIT_TOKEN"] %>

--- a/lib/link_checker/uri_checker/http_checker.rb
+++ b/lib/link_checker/uri_checker/http_checker.rb
@@ -275,10 +275,20 @@ module LinkChecker::UriChecker
     end
 
     def run_connection_request(method)
-      self.class.connection.run_request(method, uri, nil, nil) do |request|
+      self.class.connection.run_request(method, uri, nil, additional_connection_headers) do |request|
         request.options[:timeout] = RESPONSE_TIME_LIMIT
         request.options[:open_timeout] = RESPONSE_TIME_LIMIT
       end
+    end
+
+    def gov_uk_uri?
+      Plek.new.website_root.include?(uri.host)
+    end
+
+    def additional_connection_headers
+      return nil unless gov_uk_uri?
+
+      { 'Rate-Limit-Token': Rails.application.secrets.rate_limit_token }
     end
   end
 end

--- a/spec/lib/link_checker_spec.rb
+++ b/spec/lib/link_checker_spec.rb
@@ -236,6 +236,26 @@ RSpec.describe LinkChecker do
       include_examples "has no errors"
     end
 
+    context "bypassing the GOV.uk rate limiter" do
+      before do
+        stub_request(:get, uri).
+          with(headers: { "Rate-Limit-Token": Rails.application.secrets.rate_limit_token, "Accept-Encoding": "none" }).
+          to_return(status: 200)
+      end
+
+      let(:uri) { "#{Plek.new.website_root}/government/document" }
+
+      include_examples "has no errors"
+      include_examples "has no warnings"
+
+      it 'should set a Rate-Limit-Token' do
+        subject
+
+        expect(WebMock).to have_requested(:get, uri).
+          with(headers: { "Rate-Limit-Token": Rails.application.secrets.rate_limit_token, "Accept-Encoding": "none" })
+      end
+    end
+
     # context "a URL detected by Google Safebrowser API" do
     #   let(:uri) { "http://malware.testing.google.test/testing/malware/" }
     #   before do


### PR DESCRIPTION
In order to bypass the GOV.uk rate limiter the link checker api needs to set a `Rate-Limit-Token` when requesting those URIs

Blocked by alphagov/govuk-puppet/pull/6976