### PR TITLE
Fix bug in sidekiq_retries_exhausted

### DIFF
--- a/app/workers/check_worker.rb
+++ b/app/workers/check_worker.rb
@@ -6,7 +6,7 @@ class CheckWorker
 
   sidekiq_retries_exhausted do |msg|
     Check.connection_pool.with_connection do |_|
-      check = msg["args"].first
+      check = Check.find(msg["args"].first)
       check.update!(
         problem_summary: "Check failed",
         suggested_fix: "Speak to your system administrator.",

--- a/spec/workers/check_worker_spec.rb
+++ b/spec/workers/check_worker_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe CheckWorker do
 
     context "when it is unable to check the link" do
       let(:check) { FactoryGirl.create(:check, link: link, created_at: 1.hour.ago, started_at: 1.hour.ago) }
-      let(:msg) { { "args" => [check] } }
+      let(:msg) { { "args" => [check.id] } }
 
       it "sets the check to a warning" do
         described_class.within_sidekiq_retries_exhausted_block(msg) {}


### PR DESCRIPTION
The PR fixes a bug in the sidekiq_retries_exhausted block.

The args passed to the `CheckWorker` is an ID not a `Check` so it this falls over when calling `update!` on an Integer.