### PR TITLE
Link report rake task

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ Start the sidekiq worker with:
 
 `bundle exec rspec`
 
+### Report rake task
+
+```bash
+$ bundle exec rake report[links.csv]
+```
+
+This will produce a report of all broken links stored in the link checker and when they were last checked.
+
 ### Example API output
 
 ```

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -17,6 +17,10 @@ class Link < ApplicationRecord
     existing_links + new_links.select { |link| import_result.ids.include?(link.id) }
   end
 
+  def most_recent_check
+    checks.order(:created_at).first
+  end
+
   def find_check(within: 4.hours, completed: false)
     scope = checks.created_within(within)
     scope = scope.where.not(completed_at: nil) if completed

--- a/app/services/report_generator_service.rb
+++ b/app/services/report_generator_service.rb
@@ -1,0 +1,37 @@
+require "csv"
+
+class ReportGeneratorService
+  def initialize(filename)
+    @filename = filename
+  end
+
+  def call
+    CSV.open(filename, "w") do |csv|
+      csv << csv_headings
+      checks_with_errors.each do |check|
+        csv << csv_row_for_check(check)
+      end
+    end
+  end
+
+private
+
+  attr_reader :filename
+
+  def checks_with_errors
+    Link.includes(:checks)
+      .map(&:most_recent_check)
+      .compact
+      .select do |check|
+        check.completed? && check.has_errors?
+      end
+  end
+
+  def csv_row_for_check(check)
+    [check.link.uri, check.completed_at]
+  end
+
+  def csv_headings
+    %w(uri last_checked)
+  end
+end

--- a/lib/tasks/report.rake
+++ b/lib/tasks/report.rake
@@ -1,0 +1,4 @@
+desc "Generate a report of all the broken links"
+task :report, [:filename] => :environment do |_t, args|
+  ReportGeneratorService.new(args[:filename]).call
+end

--- a/spec/services/report_generator_service_spec.rb
+++ b/spec/services/report_generator_service_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe ReportGeneratorService do
+  context "with some broken links" do
+    before do
+      # completed broken links
+      5.times do |i|
+        link = FactoryGirl.create(:link, uri: "https://www.example.org/#{i}")
+        FactoryGirl.create(:check, :completed, :with_errors, link: link)
+      end
+
+      # uncompleted broken link
+      FactoryGirl.create(:check, :with_errors, link: FactoryGirl.create(:link, uri: "https://www.example.org/checking"))
+
+      # completed ok link
+      FactoryGirl.create(:check, :completed, link: FactoryGirl.create(:link))
+    end
+
+    it "creates a CSV file" do
+      Tempfile.create("report.csv") do |file|
+        described_class.new(file.path).call
+
+        expect(file.readlines.length).to eq(1 + 5)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds a new rake task which generates a report of all broken links and when they were last checked. This was requested to be able to cross reference this with the data in Google Analytics to identify how many users are affected by broken links.
  