### PR TITLE
Make connection a property of instances

### DIFF
--- a/lib/link_checker/uri_checker/http_checker.rb
+++ b/lib/link_checker/uri_checker/http_checker.rb
@@ -90,13 +90,6 @@ module LinkChecker::UriChecker
   end
 
   class HttpChecker < Checker
-    def self.connection
-      @connection ||= Faraday.new(headers: { accept_encoding: "none" }) do |faraday|
-        faraday.use :cookie_jar
-        faraday.adapter Faraday.default_adapter
-      end
-    end
-
     def call
       if uri.host.nil?
         return add_problem(NoHost.new(from_redirect: from_redirect?))
@@ -274,8 +267,15 @@ module LinkChecker::UriChecker
       end
     end
 
+    def connection
+      @connection ||= Faraday.new(headers: { accept_encoding: "none" }) do |faraday|
+        faraday.use :cookie_jar
+        faraday.adapter Faraday.default_adapter
+      end
+    end
+
     def run_connection_request(method)
-      self.class.connection.run_request(method, uri, nil, additional_connection_headers) do |request|
+      connection.run_request(method, uri, nil, additional_connection_headers) do |request|
         request.options[:timeout] = RESPONSE_TIME_LIMIT
         request.options[:open_timeout] = RESPONSE_TIME_LIMIT
       end


### PR DESCRIPTION
This should solve a concurrency issue we're seeing in Sentry where multiple workers are trying to use the same connection simulatenously.