### PR TITLE
Hide RestartWorkerException from Sentry

### DIFF
--- a/config/initializers/raven.rb
+++ b/config/initializers/raven.rb
@@ -1,0 +1,5 @@
+Raven.configure do |config|
+  config.excluded_exceptions += %w(
+    RestartWorkerException
+  )
+end


### PR DESCRIPTION
It's not necessary for this exception to come through to Sentry since it's normal behaviour.