### PR TITLE
Restrict urls Google safebrowsing is run on

### DIFF
--- a/lib/link_checker/uri_checker/http_checker.rb
+++ b/lib/link_checker/uri_checker/http_checker.rb
@@ -281,7 +281,11 @@ module LinkChecker::UriChecker
     end
 
     def gov_uk_uri?
-      Plek.new.website_root.include?(uri.host)
+      @gov_uk_uri ||= Plek.new.website_root.include?(uri.host)
+    end
+
+    def gov_uk_upload_uri?
+      uri.path.starts_with? "/government/uploads"
     end
 
     def additional_connection_headers
@@ -291,6 +295,8 @@ module LinkChecker::UriChecker
     end
 
     def use_google_safebrowsing?
+      return false if gov_uk_uri? && !gov_uk_upload_uri?
+
       Rails.env.production? || Rails.application.secrets.google_api_key
     end
   end

--- a/spec/lib/link_checker_spec.rb
+++ b/spec/lib/link_checker_spec.rb
@@ -256,16 +256,72 @@ RSpec.describe LinkChecker do
       end
     end
 
-    # context "a URL detected by Google Safebrowser API" do
-    #   let(:uri) { "http://malware.testing.google.test/testing/malware/" }
-    #   before do
-    #     stub_request(:get, uri).to_return(status: 200)
-    #     stub_request(:post, "https://safebrowsing.googleapis.com/v4/threatMatches:find?key=test")
-    #       .to_return(status: 200, body: { matches: [{ threatType: "MALWARE" }] }.to_json)
-    #   end
-    #   include_examples "has a problem summary", "Suspicious content"
-    #   include_examples "has warnings"
-    #   include_examples "has no errors"
-    # end
+    context "a URL detected by Google Safebrowser API" do
+      let(:uri) { "http://malware.testing.google.test/testing/malware/" }
+      before do
+        stub_request(:get, uri).to_return(status: 200)
+        stub_request(:post, "https://safebrowsing.googleapis.com/v4/threatMatches:find?key=test")
+          .to_return(status: 200, body: { matches: [{ threatType: "MALWARE" }] }.to_json)
+      end
+      include_examples "has a problem summary", "Suspicious content"
+      include_examples "has warnings"
+      include_examples "has no errors"
+    end
+
+    context "Google Safebrowser API on a gov.uk url" do
+      let(:uri) { "http://www.dev.gov.uk/malware.testing.google.test/testing/malware/" }
+      before do
+        stub_request(:get, uri).to_return(status: 200)
+      end
+      let(:request) do
+        stub_request(:post, "https://safebrowsing.googleapis.com/v4/threatMatches:find?key=test")
+      end
+
+      include_examples "has no warnings"
+      include_examples "has no errors"
+      it "should not make a request" do
+        subject
+
+        expect(request).to_not have_been_requested
+      end
+    end
+
+    context "Google Safebrowser API on a gov.uk upload url" do
+      let(:uri) { "http://www.dev.gov.uk/government/uploads" }
+      before do
+        stub_request(:get, uri).to_return(status: 200)
+      end
+      let(:request) do
+        stub_request(:post, "https://safebrowsing.googleapis.com/v4/threatMatches:find?key=test")
+          .to_return(status: 200, body: "{}")
+      end
+
+      include_examples "has no warnings"
+      include_examples "has no errors"
+      it "should make a request" do
+        subject
+
+        expect(request).to have_been_requested
+      end
+    end
+
+    context "Google Safebrowser API on an asset-manager upload url" do
+      let(:uri) { "https://assets.publishing.service.gov.uk/media/" }
+      before do
+        stub_request(:get, uri).to_return(status: 200)
+      end
+      let(:request) do
+        stub_request(:post, "https://safebrowsing.googleapis.com/v4/threatMatches:find?key=test")
+          .to_return(status: 200, body: "{}")
+      end
+
+      include_examples "has no warnings"
+      include_examples "has no errors"
+      it "should make a request" do
+        subject
+
+        expect(request).to have_been_requested
+      end
+    end
   end
 end


### PR DESCRIPTION
The usage limit for Google safebrowsing was being exceeded too quickly so
restricting the usage to urls that are not gov.uk ones only.