### PR TITLE
Rename GOV.UK Rate Limit configuration

### DIFF
--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -13,13 +13,13 @@
 development:
   secret_key_base: 36746f0eb3c57b16be0278bdf9a9418ec225ecd5f9a3183697a3dc0dfd3aa1d05d285b3ed42b77c92ae6deee7af6a2b9bc87f119eca9c74810dcc43ddd5eb02b
   google_api_key: <%= ENV["GOOGLE_API_KEY"] %>
-  rate_limit_token: pfB6uNKYC8sB9PVgBLdwFToN
+  govuk_rate_limit_token: pfB6uNKYC8sB9PVgBLdwFToN
   govuk_basic_auth_credentials: "test:test"
 
 test:
   secret_key_base: b81a573d7703bfdf5c80f2a201c9e9d7ec5aad3326e252534568e1a82a7fc79a09f0d8ebd5e7e0fb5fc584f6a23440f2be5c986ec723df389ef7527e3e7ffc12
   google_api_key: test
-  rate_limit_token: pfB6uNKYC8sB9PVgBLdwFToN
+  govuk_rate_limit_token: pfB6uNKYC8sB9PVgBLdwFToN
   govuk_basic_auth_credentials: "test:test"
 
 # Do not keep production secrets in the repository,
@@ -27,5 +27,5 @@ test:
 production:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
   google_api_key: <%= ENV["GOOGLE_API_KEY"] %>
-  rate_limit_token: <%= ENV["RATE_LIMIT_TOKEN"] %>
+  govuk_rate_limit_token: <%= ENV.fetch("GOVUK_RATE_LIMIT_TOKEN", ENV["RATE_LIMIT_TOKEN"]) %>
   govuk_basic_auth_credentials: <%= ENV["GOVUK_BASIC_AUTH_CREDENTIALS"] %>

--- a/lib/link_checker/uri_checker/http_checker.rb
+++ b/lib/link_checker/uri_checker/http_checker.rb
@@ -290,7 +290,7 @@ module LinkChecker::UriChecker
 
     def rate_limit_header
       return {} unless gov_uk_uri?
-      { "Rate-Limit-Token": Rails.application.secrets.rate_limit_token }
+      { "Rate-Limit-Token": Rails.application.secrets.govuk_rate_limit_token }
     end
 
     def basic_authorization_header

--- a/spec/lib/link_checker_spec.rb
+++ b/spec/lib/link_checker_spec.rb
@@ -236,10 +236,10 @@ RSpec.describe LinkChecker do
       include_examples "has no errors"
     end
 
-    context "bypassing the GOV.uk rate limiter" do
+    context "bypassing the GOV.UK rate limiter" do
       before do
         stub_request(:get, uri).
-          with(headers: { "Rate-Limit-Token": Rails.application.secrets.rate_limit_token, "Accept-Encoding": "none" }).
+          with(headers: { "Rate-Limit-Token": Rails.application.secrets.govuk_rate_limit_token, "Accept-Encoding": "none" }).
           to_return(status: 200)
       end
 
@@ -252,7 +252,7 @@ RSpec.describe LinkChecker do
         subject
 
         expect(WebMock).to have_requested(:get, uri).
-          with(headers: { "Rate-Limit-Token": Rails.application.secrets.rate_limit_token, "Accept-Encoding": "none" })
+          with(headers: { "Rate-Limit-Token": Rails.application.secrets.govuk_rate_limit_token, "Accept-Encoding": "none" })
       end
     end
 


### PR DESCRIPTION
This makes it clearer that the rate limit is only used for GOV.UK.

Depends on #120.