### PR TITLE
Revert "Make connection a property of instances"

### DIFF
--- a/lib/link_checker/uri_checker/http_checker.rb
+++ b/lib/link_checker/uri_checker/http_checker.rb
@@ -90,6 +90,13 @@ module LinkChecker::UriChecker
   end
 
   class HttpChecker < Checker
+    def self.connection
+      @connection ||= Faraday.new(headers: { accept_encoding: "none" }) do |faraday|
+        faraday.use :cookie_jar
+        faraday.adapter Faraday.default_adapter
+      end
+    end
+
     def call
       if uri.host.nil?
         return add_problem(NoHost.new(from_redirect: from_redirect?))
@@ -266,15 +273,8 @@ module LinkChecker::UriChecker
       end
     end
 
-    def connection
-      @connection ||= Faraday.new(headers: { accept_encoding: "none" }) do |faraday|
-        faraday.use :cookie_jar
-        faraday.adapter Faraday.default_adapter
-      end
-    end
-
     def run_connection_request(method)
-      connection.run_request(method, uri, nil, additional_connection_headers) do |request|
+      self.class.connection.run_request(method, uri, nil, additional_connection_headers) do |request|
         request.options[:timeout] = RESPONSE_TIME_LIMIT
         request.options[:open_timeout] = RESPONSE_TIME_LIMIT
       end


### PR DESCRIPTION
This reverts commit a75becee9748e628b6fe4b983b3a87b1cf11687e.

We need the connection to be shared across instances of the `HttpChecker` so that the cookie jar is shared. This may mean we see the concurrency issues in Sentry again which will need to be fixed separately.