### PR TITLE
Pass the Faraday http client around during a link test

### DIFF
--- a/lib/link_checker/uri_checker/checker.rb
+++ b/lib/link_checker/uri_checker/checker.rb
@@ -2,10 +2,11 @@ module LinkChecker::UriChecker
   class Checker
     attr_reader :uri, :report
 
-    def initialize(uri, redirect_history: [])
+    def initialize(uri, redirect_history: [], http_client: nil)
       @uri = uri
       @redirect_history = redirect_history
       @report = Report.new
+      @http_client = http_client
     end
 
     def from_redirect?
@@ -14,6 +15,13 @@ module LinkChecker::UriChecker
 
     def add_problem(problem)
       @report.add_problem(problem)
+    end
+
+    def http_client
+      @http_client ||= Faraday.new(headers: { accept_encoding: "none" }) do |faraday|
+        faraday.use :cookie_jar
+        faraday.adapter Faraday.default_adapter
+      end
     end
 
   private

--- a/lib/link_checker/uri_checker/valid_uri_checker.rb
+++ b/lib/link_checker/uri_checker/valid_uri_checker.rb
@@ -28,9 +28,9 @@ module LinkChecker::UriChecker
       if parsed_uri.scheme.nil?
         add_problem(MissingUriScheme.new(from_redirect: from_redirect?))
       elsif HTTP_URI_SCHEMES.include?(parsed_uri.scheme)
-        report.merge(HttpChecker.new(parsed_uri, redirect_history: redirect_history).call)
+        report.merge(HttpChecker.new(parsed_uri, redirect_history: redirect_history, http_client: http_client).call)
       elsif FILE_URI_SCHEMES.include?(parsed_uri.scheme)
-        report.merge(FileChecker.new(parsed_uri, redirect_history: redirect_history).call)
+        report.merge(FileChecker.new(parsed_uri, redirect_history: redirect_history, http_client: http_client).call)
       elsif CONTACT_SCHEMES.include?(parsed_uri.scheme)
         add_problem(ContactDetails.new(from_redirect: from_redirect?))
       else


### PR DESCRIPTION
This is to fix a thread safety issue where an ||= is run at class level
as ||= is not thread safe.

It seems unnecessary to require this at class level as we only care
about cookie jar for the duration of a links check. This therefore
introduces the concept of a http client at the checker level which can
be passed around to an additional instances of checker that are created.