### PR TITLE
Report Safebrowsing rate limiting to Statsd instead of Sentry

### DIFF
--- a/lib/link_checker/uri_checker/http_checker.rb
+++ b/lib/link_checker/uri_checker/http_checker.rb
@@ -202,6 +202,8 @@ module LinkChecker::UriChecker
         if data.include?("matches") && data["matches"]
           add_problem(PageContainsThreat.new(from_redirect: from_redirect?))
         end
+      elsif response.status == 429
+        GovukStatsd.increment 'safebrowsing.rate_limited'
       else
         GovukError.notify(
           "Unable to talk to Google Safebrowsing API!",


### PR DESCRIPTION
We don’t need to log being rate limited by Google to Sentry, but we
should keep track of the occurrences of this in Statsd. Google always
returns a 429 in this case, so we can easily differentiate.