### PR TITLE
Disable Google Safebrowsing check

### DIFF
--- a/lib/link_checker/uri_checker/http_checker.rb
+++ b/lib/link_checker/uri_checker/http_checker.rb
@@ -105,7 +105,8 @@ module LinkChecker::UriChecker
       check_meta_mature_rating
       return report if report.has_errors?
 
-      check_google_safebrowsing if use_google_safebrowsing?
+      # FIXME once a key has been correctly configured in integration, staging and production
+      # check_google_safebrowsing if use_google_safebrowsing?
 
       report
     end

--- a/spec/lib/link_checker_spec.rb
+++ b/spec/lib/link_checker_spec.rb
@@ -256,121 +256,126 @@ RSpec.describe LinkChecker do
       end
     end
 
-    context "a URL detected by Google Safebrowser API" do
-      let(:uri) { "http://malware.testing.google.test/testing/malware/" }
-      before do
-        stub_request(:get, uri).to_return(status: 200)
-        stub_request(:post, "https://safebrowsing.googleapis.com/v4/threatMatches:find?key=test")
-          .to_return(status: 200, body: { matches: [{ threatType: "MALWARE" }] }.to_json)
-      end
-      include_examples "has a problem summary", "Suspicious content"
-      include_examples "has warnings"
-      include_examples "has no errors"
-    end
-
-    context "Google Safebrowser API on a gov.uk url" do
-      let(:uri) { "http://www.dev.gov.uk/malware.testing.google.test/testing/malware/" }
-      before do
-        stub_request(:get, uri).to_return(status: 200)
-      end
-      let(:request) do
-        stub_request(:post, "https://safebrowsing.googleapis.com/v4/threatMatches:find?key=test")
-      end
-
-      include_examples "has no warnings"
-      include_examples "has no errors"
-      it "should not make a request" do
-        subject
-
-        expect(request).to_not have_been_requested
-      end
-    end
-
-    context "Google Safebrowser API on a gov.uk upload url" do
-      let(:uri) { "http://www.dev.gov.uk/government/uploads" }
-      before do
-        stub_request(:get, uri).to_return(status: 200)
-      end
-      let(:request) do
-        stub_request(:post, "https://safebrowsing.googleapis.com/v4/threatMatches:find?key=test")
-          .to_return(status: 200, body: "{}")
-      end
-
-      include_examples "has no warnings"
-      include_examples "has no errors"
-      it "should make a request" do
-        subject
-
-        expect(request).to have_been_requested
-      end
-    end
-
-    context "Google Safebrowser API on an asset-manager upload url" do
-      let(:uri) { "https://assets.publishing.service.gov.uk/media/" }
-      before do
-        stub_request(:get, uri).to_return(status: 200)
-      end
-      let(:request) do
-        stub_request(:post, "https://safebrowsing.googleapis.com/v4/threatMatches:find?key=test")
-          .to_return(status: 200, body: "{}")
-      end
-
-      include_examples "has no warnings"
-      include_examples "has no errors"
-      it "should make a request" do
-        subject
-
-        expect(request).to have_been_requested
-      end
-    end
-
-    context "Google Safebrowser API returns an error" do
-      let(:uri) { "http://www.gov.uk/government/uploads" }
-      before do
-        stub_request(:get, uri).to_return(status: 200)
-      end
-      let!(:request) do
-        stub_request(:post, "https://safebrowsing.googleapis.com/v4/threatMatches:find?key=test")
-          .to_return(status: 500, body: "an error", headers: { 'X-Foo' => 'bar' })
-      end
-
-      include_examples "has no warnings"
-      include_examples "has no errors"
-      it "should log the error to Sentry" do
-        expect(GovukError).to receive(:notify)
-          .with("Unable to talk to Google Safebrowsing API!",
-            extra: {
-              status: 500,
-              body: 'an error',
-              headers: { 'X-Foo' => 'bar' },
-            })
-
-        subject
-
-        expect(request).to have_been_requested
-      end
-    end
-
-    context "Google Safebrowser API rate limits the request" do
-      let(:uri) { "http://www.gov.uk/government/uploads" }
-      before do
-        stub_request(:get, uri).to_return(status: 200)
-      end
-      let!(:request) do
-        stub_request(:post, "https://safebrowsing.googleapis.com/v4/threatMatches:find?key=test")
-          .to_return(status: 429, body: "an error", headers: { 'X-Foo' => 'bar' })
-      end
-
-      include_examples "has no warnings"
-      include_examples "has no errors"
-      it "should increment the counter in statsd" do
-        expect(GovukStatsd).to receive(:increment).with("safebrowsing.rate_limited")
-
-        subject
-
-        expect(request).to have_been_requested
-      end
-    end
+    # Commented out as we have disabled the Google Safebrowsing intergration as the API key
+    # wasn't working properly and we were hitting the rate limit in production.
+    #
+    # FIXME uncomment all this once we've found a solution to this
+    #
+    # context "a URL detected by Google Safebrowser API" do
+    #   let(:uri) { "http://malware.testing.google.test/testing/malware/" }
+    #   before do
+    #     stub_request(:get, uri).to_return(status: 200)
+    #     stub_request(:post, "https://safebrowsing.googleapis.com/v4/threatMatches:find?key=test")
+    #       .to_return(status: 200, body: { matches: [{ threatType: "MALWARE" }] }.to_json)
+    #   end
+    #   include_examples "has a problem summary", "Suspicious content"
+    #   include_examples "has warnings"
+    #   include_examples "has no errors"
+    # end
+    #
+    # context "Google Safebrowser API on a gov.uk url" do
+    #   let(:uri) { "http://www.dev.gov.uk/malware.testing.google.test/testing/malware/" }
+    #   before do
+    #     stub_request(:get, uri).to_return(status: 200)
+    #   end
+    #   let(:request) do
+    #     stub_request(:post, "https://safebrowsing.googleapis.com/v4/threatMatches:find?key=test")
+    #   end
+    #
+    #   include_examples "has no warnings"
+    #   include_examples "has no errors"
+    #   it "should not make a request" do
+    #     subject
+    #
+    #     expect(request).to_not have_been_requested
+    #   end
+    # end
+    #
+    # context "Google Safebrowser API on a gov.uk upload url" do
+    #   let(:uri) { "http://www.dev.gov.uk/government/uploads" }
+    #   before do
+    #     stub_request(:get, uri).to_return(status: 200)
+    #   end
+    #   let(:request) do
+    #     stub_request(:post, "https://safebrowsing.googleapis.com/v4/threatMatches:find?key=test")
+    #       .to_return(status: 200, body: "{}")
+    #   end
+    #
+    #   include_examples "has no warnings"
+    #   include_examples "has no errors"
+    #   it "should make a request" do
+    #     subject
+    #
+    #     expect(request).to have_been_requested
+    #   end
+    # end
+    #
+    # context "Google Safebrowser API on an asset-manager upload url" do
+    #   let(:uri) { "https://assets.publishing.service.gov.uk/media/" }
+    #   before do
+    #     stub_request(:get, uri).to_return(status: 200)
+    #   end
+    #   let(:request) do
+    #     stub_request(:post, "https://safebrowsing.googleapis.com/v4/threatMatches:find?key=test")
+    #       .to_return(status: 200, body: "{}")
+    #   end
+    #
+    #   include_examples "has no warnings"
+    #   include_examples "has no errors"
+    #   it "should make a request" do
+    #     subject
+    #
+    #     expect(request).to have_been_requested
+    #   end
+    # end
+    #
+    # context "Google Safebrowser API returns an error" do
+    #   let(:uri) { "http://www.gov.uk/government/uploads" }
+    #   before do
+    #     stub_request(:get, uri).to_return(status: 200)
+    #   end
+    #   let!(:request) do
+    #     stub_request(:post, "https://safebrowsing.googleapis.com/v4/threatMatches:find?key=test")
+    #       .to_return(status: 500, body: "an error", headers: { 'X-Foo' => 'bar' })
+    #   end
+    #
+    #   include_examples "has no warnings"
+    #   include_examples "has no errors"
+    #   it "should log the error to Sentry" do
+    #     expect(GovukError).to receive(:notify)
+    #       .with("Unable to talk to Google Safebrowsing API!",
+    #         extra: {
+    #           status: 500,
+    #           body: 'an error',
+    #           headers: { 'X-Foo' => 'bar' },
+    #         })
+    #
+    #     subject
+    #
+    #     expect(request).to have_been_requested
+    #   end
+    # end
+    #
+    # context "Google Safebrowser API rate limits the request" do
+    #   let(:uri) { "http://www.gov.uk/government/uploads" }
+    #   before do
+    #     stub_request(:get, uri).to_return(status: 200)
+    #   end
+    #   let!(:request) do
+    #     stub_request(:post, "https://safebrowsing.googleapis.com/v4/threatMatches:find?key=test")
+    #       .to_return(status: 429, body: "an error", headers: { 'X-Foo' => 'bar' })
+    #   end
+    #
+    #   include_examples "has no warnings"
+    #   include_examples "has no errors"
+    #   it "should increment the counter in statsd" do
+    #     expect(GovukStatsd).to receive(:increment).with("safebrowsing.rate_limited")
+    #
+    #     subject
+    #
+    #     expect(request).to have_been_requested
+    #   end
+    # end
 
     context "when calling a url that requires authentication" do
       let(:host) { "www.needsauthentication.co.uk" }


### PR DESCRIPTION
The API key appears to not be correctly configured and we're seeing access denied errors from the API. For the moment we can disable this check while we figure out how to configure the keys.