### PR TITLE
Remove Sidekiq cron for ScheduleResourceMonitorWorker

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -9,6 +9,3 @@
   cleanup:
     every: 60m
     class: CleanupWorker
-  monitor:
-    cron: '0 1 * * *'
-    class: ScheduleResourceMonitorWorker


### PR DESCRIPTION
It was removed in ad09d11ef83e9698dffd1c876f7dc829dba6bde5 and is
causing errors in Sentry