### PR TITLE
Ensure WebhookWorker jobs are unique

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem "sidekiq-scheduler", "~> 2.2"
 # We can't use v5 of this because it requires redis 3 and we use 2.8
 # We use our own fork because the latest 4.x release has a bug with
 # removing jobs from the uniquejobs hash in redis
-gem "sidekiq-unique-jobs", git: "https://github.com/alphagov/sidekiq-unique-jobs", branch: 'fix-for-upstream-195-backported-to-4-x-branch', require: false
+gem "sidekiq-unique-jobs", git: "https://github.com/alphagov/sidekiq-unique-jobs", branch: 'fix-for-upstream-195-backported-to-4-x-branch'
 
 gem "activerecord-import", "~> 0.22"
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -14,6 +14,7 @@ require "spec_helper"
 require "database_cleaner"
 require "rspec/rails"
 require "govuk_sidekiq/testing"
+require "sidekiq_unique_jobs/testing"
 
 Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 

--- a/spec/workers/webhook_worker_spec.rb
+++ b/spec/workers/webhook_worker_spec.rb
@@ -25,6 +25,18 @@ RSpec.describe WebhookWorker do
           .with(headers: { "X-LinkCheckerApi-Signature": expected_signature }))
           .to have_been_requested
       end
+
+      context "when creating the job multiple times for the same batch" do
+        before do
+          10.times do
+            described_class.perform_async(report, webhook_uri, webhook_secret_token, batch_id)
+          end
+        end
+
+        it "should only put one job on the queue" do
+          expect(WebhookWorker.jobs.size).to eq(1)
+        end
+      end
     end
 
     context "with an already triggered batch" do


### PR DESCRIPTION
We recently downgraded `sidekiq-unique-jobs` to use our own fork #148, but in the process, we inadvertently added a `require: false` to the `Gemfile`. This meant that `sidekiq-unique-jobs` wasn't being loaded and therefore not being used.

This has lead to the queue [regularly hitting 2 million jobs at night since we reverted the Gem](https://grafana.integration.publishing.service.gov.uk/dashboard/file/sidekiq.json?refresh=1m&orgId=1&var-Application=link-checker-api&var-Queues=All&from=now-90d&to=now) and increasing the memory usage of Redis. I'm hoping that this will reduce at least some of the Redis out of memory errors we've been seeing recently across all the environments.