### PR TITLE
Improve SQL query to remove old batches and checks

### DIFF
--- a/app/workers/cleanup_worker.rb
+++ b/app/workers/cleanup_worker.rb
@@ -25,6 +25,6 @@ private
   end
 
   def old_batches
-    Batch.where(id: [BatchCheck.where(check: [old_checks]).pluck(:batch_id)])
+    Batch.where(id: BatchCheck.select(:batch_id).where(check: old_checks))
   end
 end

--- a/spec/workers/cleanup_worker_spec.rb
+++ b/spec/workers/cleanup_worker_spec.rb
@@ -6,11 +6,11 @@ RSpec.describe CleanupWorker do
     let(:link2) { create(:link, id: 2) }
 
     context "with an old check" do
-      let(:check1) { create(:check, link: link1, completed_at: 10.weeks.ago) }
-      let(:check2) { create(:check, link: link2, completed_at: 2.weeks.ago) }
-      let!(:batch1) { create(:batch, checks: [check1]) }
-      let!(:batch2) { create(:batch, checks: [check2]) }
-      let!(:batch3) { create(:batch, checks: [check1, check2]) }
+      let(:old_check) { create(:check, link: link1, completed_at: 10.weeks.ago) }
+      let(:new_check) { create(:check, link: link2, completed_at: 2.weeks.ago) }
+      let!(:old_batch) { create(:batch, checks: [old_check]) }
+      let!(:new_batch) { create(:batch, checks: [new_check]) }
+      let!(:old_and_new_batch) { create(:batch, checks: [old_check, new_check]) }
 
       it "removes the check and the associated batches" do
         expect(Check.count).to eq(2)
@@ -20,8 +20,10 @@ RSpec.describe CleanupWorker do
 
         expect(Check.count).to eq(1)
         expect(Batch.count).to eq(1)
-        expect(Check.first).to eq(check2)
-        expect(Batch.first).to eq(batch2)
+        expect(Check.first).to eq(new_check)
+        expect(Batch.first).to eq(new_batch)
+
+        expect { old_check.reload }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
   end


### PR DESCRIPTION
The query generated in this worker removes old batches and checks. It does so by `plucking` all the IDs of the old batches, and running a delete query on them.

When the number of old batches exceeds 65535, this will cause an SQL error:

```
ActiveRecord::StatementInvalid: PG::UnableToSend: number of parameters must be between 0 and 65535\n: DELETE FROM \"batches\" WHERE \"batches\".\"id\" IN ($1, $2, $3, $4, $...
```

This in turn causes billions of log files from Sidekiq, which is currently taking down machines on integration.

This commit changes the query so that we feed in the `BatchCheck.where(check: [old_checks])` directly, which Rails will magically use to generate a subquery, as evidenced by running this in the console:

```rb
irb(main):008:0> puts Batch.where(id: BatchCheck.where(check: [old_checks])).to_sql
SELECT "batches".* FROM "batches" WHERE "batches"."id" IN (SELECT "batch_checks"."id" FROM "batch_checks" WHERE "batch_checks"."check_id" IN (SELECT "checks"."id" FROM "checks" WHERE (completed_at < '2018-04-05 10:06:49.607593')))
```

We've improved the tests a bit to make sure that we haven't broken anything.