### PR TITLE
Send Faraday errors to the logs

### DIFF
--- a/app/workers/webhook_worker.rb
+++ b/app/workers/webhook_worker.rb
@@ -32,7 +32,8 @@ class WebhookWorker
     end
 
     batch.update!(webhook_triggered: true)
-  rescue Faraday::ClientError
+  rescue Faraday::ClientError => e
+    logger.error e.message
     raise RestartWorkerException.new
   end
 


### PR DESCRIPTION
This allows us to see why these might be failing rather than currently where we ignore the exception.

We need this to figure out something that's going wrong in AWS.