### PR TITLE
Fix rubocop static attribute deprecations

### DIFF
--- a/spec/factories/checks.rb
+++ b/spec/factories/checks.rb
@@ -1,9 +1,9 @@
 FactoryBot.define do
   factory :check do
-    started_at nil
-    completed_at nil
-    link_warnings Array.new
-    link_errors Array.new
+    started_at { nil }
+    completed_at { nil }
+    link_warnings { Array.new }
+    link_errors { Array.new }
 
     trait :completed do
       started_at { 10.minutes.ago }

--- a/spec/factories/links.rb
+++ b/spec/factories/links.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :link do
-    uri "https://www.gov.uk"
+    uri { "https://www.gov.uk" }
   end
 end


### PR DESCRIPTION
Done using the advised command of:

rubocop \
  --require rubocop-rspec \
  --only FactoryBot/AttributeDefinedStatically \
  --auto-correct