### PR TITLE
Authenticate on all routes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 source "https://rubygems.org"
 
 gem "activerecord-import", "~> 0.27"
-gem "database_cleaner"
 gem "deprecated_columns"
 gem "faraday", "~> 0.15"
 gem "faraday-cookie_jar", "~> 0.0.6"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,7 +70,6 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.4)
-    database_cleaner (1.7.0)
     deprecated_columns (0.1.1)
       rails (>= 4.0)
     diff-lcs (1.3)
@@ -363,7 +362,6 @@ DEPENDENCIES
   activerecord-import (~> 0.27)
   byebug
   climate_control (~> 0.2.0)
-  database_cleaner
   deprecated_columns
   factory_bot_rails (~> 4.11)
   faraday (~> 0.15)

--- a/app/controllers/batch_controller.rb
+++ b/app/controllers/batch_controller.rb
@@ -1,6 +1,4 @@
 class BatchController < ApplicationController
-  skip_before_action :authenticate_user!, only: [:show]
-
   class CreateParams
     include ActiveModel::Validations
 

--- a/app/controllers/check_controller.rb
+++ b/app/controllers/check_controller.rb
@@ -1,6 +1,4 @@
 class CheckController < ApplicationController
-  skip_before_action :authenticate_user!, only: [:check]
-
   class CheckParams
     include ActiveModel::Validations
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,5 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+
+User.find_or_create_by!(name: "Test user")

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -11,7 +11,6 @@ require File.expand_path("../../config/environment", __FILE__)
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 
 require "spec_helper"
-require "database_cleaner"
 require "rspec/rails"
 require "govuk_sidekiq/testing"
 require "sidekiq_unique_jobs/testing"
@@ -20,19 +19,7 @@ Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 
 RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
-
-  config.before(:suite) do
-    DatabaseCleaner.strategy = :transaction
-    DatabaseCleaner.clean_with(:truncation)
-  end
-
-  config.around(:each) do |example|
-    if example.metadata[:skip_cleaning]
-      example.run
-    else
-      DatabaseCleaner.cleaning { example.run }
-    end
-  end
+  config.use_transactional_fixtures = true
 
   config.infer_spec_type_from_file_location!
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -21,5 +21,9 @@ RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
   config.use_transactional_fixtures = true
 
+  config.before :suite do
+    Rails.application.load_seed
+  end
+
   config.infer_spec_type_from_file_location!
 end

--- a/spec/requests/batch_spec.rb
+++ b/spec/requests/batch_spec.rb
@@ -326,7 +326,7 @@ RSpec.describe "/batch endpoint" do
   describe "GET /batch/:id" do
     context "when requesting a batch that doesn't exist" do
       it "returns 404" do
-        expect { get "/batch/432" }.to raise_error(ActiveRecord::RecordNotFound)
+        expect { get "/batch/432", headers: { "Authorization" => "Bearer Token123" } }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
 
@@ -353,7 +353,7 @@ RSpec.describe "/batch endpoint" do
           ],
         )
 
-        get "/batch/#{batch_id}"
+        get "/batch/#{batch_id}", headers: { "Authorization" => "Bearer Token123" }
       end
 
       let(:batch_report) do
@@ -391,7 +391,7 @@ RSpec.describe "/batch endpoint" do
           ],
         )
 
-        get "/batch/#{batch_id}"
+        get "/batch/#{batch_id}", headers: { "Authorization" => "Bearer Token123" }
       end
 
       let(:batch_report) do
@@ -406,6 +406,17 @@ RSpec.describe "/batch endpoint" do
       end
 
       include_examples "returns batch report", 200
+    end
+
+    context "when the user is not authenticated" do
+      around do |example|
+        ClimateControl.modify(GDS_SSO_MOCK_INVALID: "1") { example.run }
+      end
+
+      it "returns an unauthorized response" do
+        get '/batch/123', params: {}.to_json
+        expect(response).to be_unauthorized
+      end
     end
   end
 end

--- a/spec/requests/batch_spec.rb
+++ b/spec/requests/batch_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "/batch endpoint" do
       before do
         post "/batch",
              params: batch_request.to_json,
-             headers: { "Content-Type" => "application/json", "Authorization" => "Bearer Token123" }
+             headers: { "Content-Type" => "application/json" }
       end
 
       include_examples "returns batch report"
@@ -54,7 +54,7 @@ RSpec.describe "/batch endpoint" do
       before do
         post "/batch",
              params: batch_request.to_json,
-             headers: { "Content-Type" => "application/json", "Authorization" => "Bearer Token123" }
+             headers: { "Content-Type" => "application/json" }
       end
 
       it "creates a batch with a secret key" do
@@ -79,7 +79,7 @@ RSpec.describe "/batch endpoint" do
       before do
         post "/batch",
              params: batch_request.to_json,
-             headers: { "Content-Type" => "application/json", "Authorization" => "Bearer Token123" }
+             headers: { "Content-Type" => "application/json" }
       end
 
       include_examples "returns batch report"
@@ -101,7 +101,7 @@ RSpec.describe "/batch endpoint" do
       before do
         post "/batch",
              params: batch_request.to_json,
-             headers: { "Content-Type" => "application/json", "Authorization" => "Bearer Token123" }
+             headers: { "Content-Type" => "application/json" }
       end
 
       include_examples "returns batch report"
@@ -131,7 +131,7 @@ RSpec.describe "/batch endpoint" do
 
         post "/batch",
              params: batch_request.to_json,
-             headers: { "Content-Type": "application/json", "Authorization" => "Bearer Token123" }
+             headers: { "Content-Type": "application/json" }
       end
 
       include_examples "returns batch report"
@@ -167,7 +167,7 @@ RSpec.describe "/batch endpoint" do
 
         post "/batch",
              params: batch_request.to_json,
-             headers: { "Content-Type": "application/json", "Authorization" => "Bearer Token123" }
+             headers: { "Content-Type": "application/json" }
       end
 
       include_examples "returns batch report", 201
@@ -177,7 +177,7 @@ RSpec.describe "/batch endpoint" do
       let(:batch_request) { build_batch_request(uris: []) }
 
       it "returns 400" do
-        expect { post "/batch", params: batch_request.to_json, headers: { "Content-Type": "application/json", "Authorization" => "Bearer Token123" } }
+        expect { post "/batch", params: batch_request.to_json, headers: { "Content-Type": "application/json" } }
           .to raise_error(ActiveModel::ValidationError)
       end
     end
@@ -186,7 +186,7 @@ RSpec.describe "/batch endpoint" do
       let(:batch_request) { build_batch_request(uris: ["http://example.com"] * 5001) }
 
       it "returns 400" do
-        expect { post "/batch", params: batch_request.to_json, headers: { "Content-Type": "application/json", "Authorization" => "Bearer Token123" } }
+        expect { post "/batch", params: batch_request.to_json, headers: { "Content-Type": "application/json" } }
           .to raise_error(ActiveModel::ValidationError)
       end
     end
@@ -229,7 +229,7 @@ RSpec.describe "/batch endpoint" do
 
         post "/batch",
              params: batch_request.to_json,
-             headers: { "Content-Type": "application/json", "Authorization" => "Bearer Token123" }
+             headers: { "Content-Type": "application/json" }
       end
 
       include_examples "returns batch report"
@@ -275,7 +275,7 @@ RSpec.describe "/batch endpoint" do
           Sidekiq::Testing.inline! do
             post "/batch",
                  params: batch_request.to_json,
-                 headers: { "Content-Type": "application/json", "Authorization" => "Bearer Token123" }
+                 headers: { "Content-Type": "application/json" }
           end
         end
 
@@ -300,7 +300,7 @@ RSpec.describe "/batch endpoint" do
         before do
           post "/batch",
                params: batch_request.to_json,
-               headers: { "Content-Type": "application/json", "Authorization" => "Bearer Token123" }
+               headers: { "Content-Type": "application/json" }
         end
 
         it "doesn't post a request to the webhook_uri" do
@@ -326,7 +326,7 @@ RSpec.describe "/batch endpoint" do
   describe "GET /batch/:id" do
     context "when requesting a batch that doesn't exist" do
       it "returns 404" do
-        expect { get "/batch/432", headers: { "Authorization" => "Bearer Token123" } }.to raise_error(ActiveRecord::RecordNotFound)
+        expect { get "/batch/432" }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
 
@@ -353,7 +353,7 @@ RSpec.describe "/batch endpoint" do
           ],
         )
 
-        get "/batch/#{batch_id}", headers: { "Authorization" => "Bearer Token123" }
+        get "/batch/#{batch_id}"
       end
 
       let(:batch_report) do
@@ -391,7 +391,7 @@ RSpec.describe "/batch endpoint" do
           ],
         )
 
-        get "/batch/#{batch_id}", headers: { "Authorization" => "Bearer Token123" }
+        get "/batch/#{batch_id}"
       end
 
       let(:batch_report) do

--- a/spec/requests/check_spec.rb
+++ b/spec/requests/check_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "check path", type: :request do
 
   context "when no uri is requested" do
     it "raises a validation error" do
-      expect { get check_link_path, headers: { "Authorization" => "Bearer Token123" } }.to raise_error(ActiveModel::ValidationError)
+      expect { get check_link_path }.to raise_error(ActiveModel::ValidationError)
     end
   end
 
@@ -36,7 +36,7 @@ RSpec.describe "check path", type: :request do
         completed_at: 1.minute.ago,
       )
 
-      get check_link_path(uri: uri), headers: { "Authorization" => "Bearer Token123" }
+      get check_link_path(uri: uri)
     end
 
     include_examples "returns link report"
@@ -45,7 +45,7 @@ RSpec.describe "check path", type: :request do
   context "when an unchecked uri is requested" do
     let(:link_report) { build_link_report(uri: uri, status: "pending") }
 
-    before { get check_link_path(uri: uri), headers: { "Authorization" => "Bearer Token123" } }
+    before { get check_link_path(uri: uri) }
 
     include_examples "returns link report"
   end
@@ -62,7 +62,7 @@ RSpec.describe "check path", type: :request do
         completed_at: 1.minute.ago,
       )
 
-      get check_link_path(uri: uri), headers: { "Authorization" => "Bearer Token123" }
+      get check_link_path(uri: uri)
     end
 
     include_examples "returns link report"
@@ -80,7 +80,7 @@ RSpec.describe "check path", type: :request do
         completed_at: 1.minute.ago,
       )
 
-      get check_link_path(uri: uri), headers: { "Authorization" => "Bearer Token123" }
+      get check_link_path(uri: uri)
     end
 
     include_examples "returns link report"
@@ -97,7 +97,7 @@ RSpec.describe "check path", type: :request do
         created_at: 11.minute.ago,
       )
 
-      get check_link_path(uri: uri, checked_within: 5.minutes.to_i), headers: { "Authorization" => "Bearer Token123" }
+      get check_link_path(uri: uri, checked_within: 5.minutes.to_i)
     end
 
     include_examples "returns link report"
@@ -112,7 +112,7 @@ RSpec.describe "check path", type: :request do
       stub_request(:post, "https://safebrowsing.googleapis.com/v4/threatMatches:find?key=test")
         .to_return(status: 200, body: "{}")
 
-      get check_link_path(uri: uri, synchronous: "true"), headers: { "Authorization" => "Bearer Token123" }
+      get check_link_path(uri: uri, synchronous: "true")
     end
 
     include_examples "returns link report"
@@ -129,7 +129,7 @@ RSpec.describe "check path", type: :request do
       stub_request(:post, "https://safebrowsing.googleapis.com/v4/threatMatches:find?key=test")
         .to_return(status: 200, body: "{}")
 
-      get check_link_path(uri: uri, synchronous: true), headers: { "Authorization" => "Bearer Token123" }
+      get check_link_path(uri: uri, synchronous: true)
     end
 
     include_examples "returns link report"

--- a/spec/requests/check_spec.rb
+++ b/spec/requests/check_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "check path", type: :request do
 
   context "when no uri is requested" do
     it "raises a validation error" do
-      expect { get check_link_path }.to raise_error(ActiveModel::ValidationError)
+      expect { get check_link_path, headers: { "Authorization" => "Bearer Token123" } }.to raise_error(ActiveModel::ValidationError)
     end
   end
 
@@ -36,7 +36,7 @@ RSpec.describe "check path", type: :request do
         completed_at: 1.minute.ago,
       )
 
-      get check_link_path(uri: uri)
+      get check_link_path(uri: uri), headers: { "Authorization" => "Bearer Token123" }
     end
 
     include_examples "returns link report"
@@ -45,7 +45,7 @@ RSpec.describe "check path", type: :request do
   context "when an unchecked uri is requested" do
     let(:link_report) { build_link_report(uri: uri, status: "pending") }
 
-    before { get check_link_path(uri: uri) }
+    before { get check_link_path(uri: uri), headers: { "Authorization" => "Bearer Token123" } }
 
     include_examples "returns link report"
   end
@@ -62,7 +62,7 @@ RSpec.describe "check path", type: :request do
         completed_at: 1.minute.ago,
       )
 
-      get check_link_path(uri: uri)
+      get check_link_path(uri: uri), headers: { "Authorization" => "Bearer Token123" }
     end
 
     include_examples "returns link report"
@@ -80,7 +80,7 @@ RSpec.describe "check path", type: :request do
         completed_at: 1.minute.ago,
       )
 
-      get check_link_path(uri: uri)
+      get check_link_path(uri: uri), headers: { "Authorization" => "Bearer Token123" }
     end
 
     include_examples "returns link report"
@@ -97,7 +97,7 @@ RSpec.describe "check path", type: :request do
         created_at: 11.minute.ago,
       )
 
-      get check_link_path(uri: uri, checked_within: 5.minutes.to_i)
+      get check_link_path(uri: uri, checked_within: 5.minutes.to_i), headers: { "Authorization" => "Bearer Token123" }
     end
 
     include_examples "returns link report"
@@ -112,7 +112,7 @@ RSpec.describe "check path", type: :request do
       stub_request(:post, "https://safebrowsing.googleapis.com/v4/threatMatches:find?key=test")
         .to_return(status: 200, body: "{}")
 
-      get check_link_path(uri: uri, synchronous: "true")
+      get check_link_path(uri: uri, synchronous: "true"), headers: { "Authorization" => "Bearer Token123" }
     end
 
     include_examples "returns link report"
@@ -129,9 +129,20 @@ RSpec.describe "check path", type: :request do
       stub_request(:post, "https://safebrowsing.googleapis.com/v4/threatMatches:find?key=test")
         .to_return(status: 200, body: "{}")
 
-      get check_link_path(uri: uri, synchronous: true)
+      get check_link_path(uri: uri, synchronous: true), headers: { "Authorization" => "Bearer Token123" }
     end
 
     include_examples "returns link report"
+  end
+
+  context "when the user is not authenticated" do
+    around do |example|
+      ClimateControl.modify(GDS_SSO_MOCK_INVALID: "1") { example.run }
+    end
+
+    it "returns an unauthorized response" do
+      get check_link_path(uri: "http://www.example.com/page", synchronous: true)
+      expect(response).to be_unauthorized
+    end
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/2IdzHdtp/26-add-authentication-to-link-checker-api

This builds on https://github.com/alphagov/link-checker-api/pull/227 to add authentication for all routes as there's not a need for unauthenticated access to this app.

It updates the tests for authentication to be consistent with approaches used on other GOV.UK apps.