### PR TITLE
Fix link-checker-api for local docker dev

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -46,4 +46,6 @@ Rails.application.configure do
 
   # Return debugging information in the format of the request
   config.debug_exception_response_format = :api
+
+  config.hosts << "link-checker-api.dev.gov.uk"
 end


### PR DESCRIPTION
The reason why https://github.com/alphagov/govuk-docker/blob/master/services/nginx-proxy/docker-compose.yml#L42 isn't working out of the box is that link-checker-api is on Rails 6, which now [has "Host Authorization" middleware](https://www.fngtps.com/2019/rails6-blocked-host/) to prevent against DNS rebinding attacks.

As far as I know, [no other GOV.UK applications are running Rails 6](https://github.com/search?q=org%3Aalphagov+%22gem+rails%22&type=Code) yet.

Without this fix, we get this error when running 'govuk-docker startup':
> Warning: Unable to communicate with application within 30 seconds.

And it meant if we ran this:
 `curl -s http://link-checker-api.dev.gov.uk/check\?uri\=https%3A%2F%2Fwww.gov.uk%2F`

We'd get this error:
> Blocked host: link-checker-api.dev.gov.uk
> To allow requests to link-checker-api.dev.gov.uk, add the following to your environment configuration:
> config.hosts << link-checker-api.dev.gov.uk