### PR TITLE
Remove 'alpha' status and reference to 2017

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,7 @@
 # Link Checker API
 
-**⚠️ This service is in Alpha ⚠️**
-
 A web service that takes an input of URIs. It performs a number of checks on
 them to determine whether these are things that should be linked to.
-
-This service was created in the GOV.UK 2 week blitz of April 2017, thoughts on
-next steps are documented in [docs/blitz.md](docs/blitz.md).
 
 ## Nomenclature
 


### PR DESCRIPTION
This service is now actively used by several publishing apps. Having it labelled as "Alpha"
is slightly doing it a disservice!