### PR TITLE
Set a value for the user agent header for webhook requests

### DIFF
--- a/app/workers/webhook_worker.rb
+++ b/app/workers/webhook_worker.rb
@@ -27,6 +27,7 @@ class WebhookWorker
     connection.post do |req|
       req.url uri
       req.headers["Content-Type"] = "application/json"
+      req.headers["User-Agent"] = "#{ENV.fetch('GOVUK_APP_NAME', 'link-checker-api')} (webhook-worker)"
       req.headers[SIGNATURE_HEADER] = generate_signature(body, secret_token) if secret_token
       req.body = body
     end


### PR DESCRIPTION
Otherwise I think Faraday plus the gem version is used, which isn't
very informative about where the requests are coming from.