### PR TITLE
Allow checked_within to be 0

### DIFF
--- a/app/controllers/batch_controller.rb
+++ b/app/controllers/batch_controller.rb
@@ -5,7 +5,7 @@ class BatchController < ApplicationController
     attr_accessor :uris, :checked_within, :priority, :webhook_uri, :webhook_secret_token
 
     validates :uris, presence: true, length: { maximum: 5000 }
-    validates :checked_within, numericality: { greater_than: 0 }
+    validates :checked_within, numericality: { greater_than_or_equal_to: 0 }
     validates :priority, inclusion: { in: %w(low high) }
 
     def initialize(params)

--- a/app/controllers/check_controller.rb
+++ b/app/controllers/check_controller.rb
@@ -6,7 +6,7 @@ class CheckController < ApplicationController
 
     validates :uri, presence: true, allow_blank: false
     validates :synchronous, inclusion: { in: [true, false] }
-    validates :checked_within, numericality: { greater_than: 0 }
+    validates :checked_within, numericality: { greater_than_or_equal_to: 0 }
     validates :priority, inclusion: { in: %w(low high) }
 
     def initialize(params)


### PR DESCRIPTION
This resolves issue #128 where the documentation and code disagree. The
use of a checked_within of 0 can indicate that an application does not
want any previous link checks included in results - this is the
appropriate situation for when an editor has corrected links and wants
fresh checks.

Addresses https://github.com/alphagov/link-checker-api/issues/128