### PR TITLE
Treat SSL issues as warnings

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -98,9 +98,9 @@ en:
     singular: This page is not responding.
     redirect: This redirects to a page that is not responding.
 
-  security_error: Security Error
+  security_problem: Security problem
   page_has_security_problem:
-    singular: This page has a security problem that users will be alerted to.
+    singular: This page has a security problem that users may be alerted to.
     redirect: This redirects to a page with a security problem.
 
   page_failing_to_load:

--- a/lib/link_checker/uri_checker/problem.rb
+++ b/lib/link_checker/uri_checker/problem.rb
@@ -59,6 +59,7 @@ module LinkChecker::UriChecker
       SlowResponse
       PageWithRating
       PageContainsThreat
+      SecurityProblem
     ].freeze
   end
 end

--- a/spec/lib/link_checker_spec.rb
+++ b/spec/lib/link_checker_spec.rb
@@ -112,10 +112,16 @@ RSpec.describe LinkChecker do
 
     context "SSL error" do
       let(:uri) { "http://www.not-gov.uk/ssl_error" }
-      before { stub_request(:get, uri).to_raise(Faraday::SSLError) }
-      include_examples "has a problem summary", "Security Error"
+      before do
+        stub_request(:get, uri).
+          to_raise(Faraday::SSLError).then.
+          to_return(status: 404)
+      end
+      # 404 has a higher priority than SSL error, so it'll be the
+      # displayed problem summary.
+      include_examples "has a problem summary", "Page not found"
       include_examples "has errors"
-      include_examples "has no warnings"
+      include_examples "has warnings"
     end
 
     context "slow response" do


### PR DESCRIPTION
There are many local authority websites which have misconfigured SSL
certs: they only send the leaf cert and not the full chain.  This is
incorrect according to the standard, and SSL checker tools (like
ssllabs.com) will flag this up.  But browsers will often work with
such websites: they cache certs, and so if the user has visited a
website which does serve the intermediate cert, then the website which
doesn't will work.

Since a user visiting the page in a browser gets the page, the link
"works", even though it technically has a problem.  There are a lot of
websites with this issue, so it really diminishes the value of the
link-checker-api to report these as hard errors.

We're not in the business of monitoring other people's websites for
configuration issues, so we're downgrading this issue to a warning.

---

[Trello card](https://trello.com/c/pKNcv0og/1279-investigate-link-checker-api-tls-failures)