### PR TITLE
Use `rubocop-govuk`, not `govuk-lint`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,3 @@
+inherit_gem:
+  rubocop-govuk:
+    - config/default.yml

--- a/Gemfile
+++ b/Gemfile
@@ -20,9 +20,9 @@ group :development, :test do
   gem "byebug" # Comes standard with Rails
   gem "climate_control", "~> 0.2.0"
   gem "factory_bot_rails", "~> 5.1"
-  gem "govuk-lint"
   gem "pry"
   gem "rspec-rails", "~> 3.9"
+  gem "rubocop-govuk"
   gem "simplecov", "~> 0.18", require: false
   gem "simplecov-rcov", "~> 0.2", require: false
   gem "timecop"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,11 +121,6 @@ GEM
       warden-oauth2 (~> 0.0.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    govuk-lint (4.3.0)
-      rubocop (~> 0.76)
-      rubocop-rails (~> 2)
-      rubocop-rspec (~> 1.28)
-      scss_lint
     govuk_app_config (2.0.3)
       logstasher (>= 1.2.2, < 1.4.0)
       sentry-raven (>= 2.7.1, < 2.14.0)
@@ -195,8 +190,8 @@ GEM
     omniauth-oauth2 (1.3.1)
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
-    parallel (1.18.0)
-    parser (2.6.5.0)
+    parallel (1.19.1)
+    parser (2.7.0.3)
       ast (~> 2.4.0)
     pg (1.2.2)
     plek (3.0.0)
@@ -277,29 +272,26 @@ GEM
       rspec-core (~> 3.0, >= 3.0.0)
       sidekiq (>= 2.4.0)
     rspec-support (3.9.0)
-    rubocop (0.76.0)
+    rubocop (0.77.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.6)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
-    rubocop-rails (2.3.2)
+    rubocop-govuk (2.0.0)
+      rubocop (= 0.77)
+      rubocop-rails (~> 2)
+      rubocop-rspec (~> 1.28)
+    rubocop-rails (2.4.2)
       rack (>= 1.1)
       rubocop (>= 0.72.0)
-    rubocop-rspec (1.36.0)
+    rubocop-rspec (1.38.1)
       rubocop (>= 0.68.1)
     ruby-progressbar (1.10.1)
     rufus-scheduler (3.6.0)
       fugit (~> 1.1, >= 1.1.6)
     safe_yaml (1.0.5)
-    sass (3.7.4)
-      sass-listen (~> 4.0.0)
-    sass-listen (4.0.0)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
-    scss_lint (0.59.0)
-      sass (~> 3.5, >= 3.5.5)
     sentry-raven (2.13.0)
       faraday (>= 0.7.6, < 1.0)
     sidekiq (5.2.7)
@@ -343,7 +335,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.6)
-    unicode-display_width (1.6.0)
+    unicode-display_width (1.6.1)
     unicorn (5.5.3)
       kgio (~> 2.6)
       raindrops (~> 0.7)
@@ -377,7 +369,6 @@ DEPENDENCIES
   faraday (~> 0.17)
   faraday-cookie_jar (~> 0.0.6)
   gds-sso (~> 14.2)
-  govuk-lint
   govuk_app_config (~> 2.0)
   govuk_sidekiq (~> 3.0)
   listen
@@ -388,6 +379,7 @@ DEPENDENCIES
   rspec-its
   rspec-rails (~> 3.9)
   rspec-sidekiq (~> 3.0)
+  rubocop-govuk
   sidekiq-scheduler (~> 3.0)
   sidekiq-unique-jobs!
   simplecov (~> 0.18)
@@ -397,4 +389,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.16.2
+   1.17.2


### PR DESCRIPTION
- The `govuk-lint` gem is deprecated. The new standard is to run RuboCop
  with an inherited set of rules.
- Only lint standard Ruby language problems, don't lint Rails as well as
  there are way more errors. That can be a stretch goal.