### PR TITLE
Always print code coverage after running tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,6 @@ group :development, :test do
   gem "rspec-rails"
   gem "rubocop-govuk"
   gem "simplecov", require: false
-  gem "simplecov-rcov", require: false
   gem "timecop"
   gem "webmock"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -316,8 +316,6 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
     simplecov-html (0.12.2)
-    simplecov-rcov (0.2.3)
-      simplecov (>= 0.4.1)
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -385,7 +383,6 @@ DEPENDENCIES
   sidekiq-scheduler
   sidekiq-unique-jobs
   simplecov
-  simplecov-rcov
   timecop
   web-console
   webmock

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,9 +1,6 @@
-if ENV["RCOV"]
-  require "simplecov"
-  require "simplecov-rcov"
-  SimpleCov.formatter = SimpleCov::Formatter::RcovFormatter
-  SimpleCov.start "rails"
-end
+require "simplecov"
+SimpleCov.start "rails"
+
 # This file is copied to spec/ when you run "rails generate rspec:install"
 ENV["RAILS_ENV"] ||= "test"
 require File.expand_path("../config/environment", __dir__)


### PR DESCRIPTION
https://trello.com/c/epNWudCR/176-write-an-rfc-for-continuous-deployment-and-seek-review

We should always monitor the amount of code that is exercised when
we run our tests.