### PR TITLE
Remove unnecessary Jenkins arguments

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 
 library("govuk")
 
-node("postgresql-9.3") {
+node {
   govuk.buildProject(
     brakeman: true,
   )

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,8 +4,6 @@ library("govuk")
 
 node("postgresql-9.3") {
   govuk.buildProject(
-    beforeTest: { -> sh("bundle exec rake db:environment:set") },
     brakeman: true,
-    rubyLintDiff: false,
   )
 }


### PR DESCRIPTION
We don't need to do the db:environment:set as Jenkins sets an env var of `DISABLE_DATABASE_ENVIRONMENT_CHECK` [1] and the rubyLintDiff argument is removed.

[1]: https://github.com/alphagov/govuk-jenkinslib/blob/4bbef0e5a3250770684ae29de8fbe2ac34d7f8b8/vars/govuk.groovy#L101