### PR TITLE
Support technically invalid, but still working, URIs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 gem "rails", "6.1.1"
 
 gem "activerecord-import"
+gem "addressable"
 gem "deprecated_columns"
 gem "faraday"
 gem "faraday-cookie_jar"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -365,6 +365,7 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-import
+  addressable
   byebug
   climate_control
   deprecated_columns

--- a/app/lib/link_checker/uri_checker/http_checker.rb
+++ b/app/lib/link_checker/uri_checker/http_checker.rb
@@ -279,7 +279,7 @@ module LinkChecker::UriChecker
 
     def run_connection_request(method, check_ssl: true)
       client = check_ssl ? http_client : insecure_http_client
-      client.run_request(method, uri, nil, additional_connection_headers) do |request|
+      client.run_request(method, uri.normalize, nil, additional_connection_headers) do |request|
         request.options[:timeout] = RESPONSE_TIME_LIMIT
         request.options[:open_timeout] = RESPONSE_TIME_LIMIT
       end

--- a/app/lib/link_checker/uri_checker/http_checker.rb
+++ b/app/lib/link_checker/uri_checker/http_checker.rb
@@ -97,7 +97,7 @@ module LinkChecker::UriChecker
 
   class HttpChecker < Checker
     def call
-      if uri.host.nil?
+      if uri.host.blank?
         return add_problem(NoHost.new(from_redirect: from_redirect?))
       end
 

--- a/app/lib/link_checker/uri_checker/valid_uri_checker.rb
+++ b/app/lib/link_checker/uri_checker/valid_uri_checker.rb
@@ -36,7 +36,7 @@ module LinkChecker::UriChecker
       else
         add_problem(UnusualUrl.new(from_redirect: from_redirect?))
       end
-    rescue URI::InvalidURIError
+    rescue Addressable::URI::InvalidURIError
       add_problem(InvalidUri.new(from_redirect: from_redirect?))
     end
 
@@ -47,7 +47,7 @@ module LinkChecker::UriChecker
     CONTACT_SCHEMES = %w[mailto tel].freeze
 
     def parsed_uri
-      @parsed_uri ||= URI.parse(uri)
+      @parsed_uri ||= Addressable::URI.parse(uri)
     end
   end
 end

--- a/app/lib/link_checker/uri_checker/valid_uri_checker.rb
+++ b/app/lib/link_checker/uri_checker/valid_uri_checker.rb
@@ -25,7 +25,7 @@ module LinkChecker::UriChecker
 
   class ValidUriChecker < Checker
     def call
-      if parsed_uri.scheme.nil?
+      if parsed_uri.scheme.blank?
         add_problem(MissingUriScheme.new(from_redirect: from_redirect?))
       elsif HTTP_URI_SCHEMES.include?(parsed_uri.scheme)
         report.merge(HttpChecker.new(parsed_uri, redirect_history: redirect_history, http_client: http_client).call)

--- a/lib/tasks/check.rake
+++ b/lib/tasks/check.rake
@@ -1,0 +1,19 @@
+desc "Check a link manually and print the report"
+task :check, [:uri] => :environment do |_t, args|
+  report = LinkChecker.new(args.fetch(:uri)).call
+
+  puts "# Summary"
+  puts report.problem_summary
+  puts
+
+  puts "# Suggested Fix"
+  puts report.suggested_fix
+  puts
+
+  puts "# Errors"
+  report.errors.each { |s| puts(s) }
+  puts
+
+  puts "# Warnings"
+  report.warnings.each { |s| puts(s) }
+end

--- a/spec/lib/link_checker_spec.rb
+++ b/spec/lib/link_checker_spec.rb
@@ -37,6 +37,8 @@ RSpec.describe LinkChecker do
     before do
       stub_request(:get, "https://www.gov.uk/ok").to_return(status: 200)
 
+      stub_request(:get, "https://www.gov.uk?key[]=value").to_return(status: 200)
+
       stub_request(:post, "https://safebrowsing.googleapis.com/v4/threatMatches:find?key=test")
         .to_return(status: 200, body: "{}")
     end
@@ -71,6 +73,13 @@ RSpec.describe LinkChecker do
 
     context "URI with supported scheme" do
       let(:uri) { "https://www.gov.uk/ok" }
+      include_examples "has no errors"
+      include_examples "has no warnings"
+    end
+
+    context "Invalid URI which can be normalised" do
+      # [] _should_ be percent-encoded, but browsers will accept it not being
+      let(:uri) { "https://www.gov.uk?key[]=value" }
       include_examples "has no errors"
       include_examples "has no warnings"
     end


### PR DESCRIPTION
Often there will be URIs which are technically invalid (for example using the `[` character instead of percent encoding it) but browsers will still accept them to, and do the encoding itself before making the request.

This PR updates Link Checker API to mimic the behaviour of browsers so that we see fewer invalid URIs which would actually work in the real world.

An example URI which was flagged as invalid was `https://m.luton.gov.uk/Page/Show/Council_tax/help-[paying-or-reducing-your-council-tax/Pages/default.aspx?redirectToMobile=True` which does work if you go to it in a browser.

[Trello Card](https://trello.com/c/YSVcZtIB/2297-3-link-checking-reports-a-working-url-as-invalid)