### PR TITLE
Set User-Agent to a recent version of Chrome

### DIFF
--- a/app/lib/link_checker/uri_checker/checker.rb
+++ b/app/lib/link_checker/uri_checker/checker.rb
@@ -30,8 +30,10 @@ module LinkChecker::UriChecker
 
     attr_reader :redirect_history
 
+    USER_AGENT = "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36".freeze
+
     def client(options = {})
-      default_options = { headers: { accept_encoding: "none" } }
+      default_options = { headers: { accept_encoding: "none", user_agent: USER_AGENT } }
       Faraday.new(default_options.merge(options)) do |faraday|
         faraday.use :cookie_jar
         faraday.adapter Faraday.default_adapter


### PR DESCRIPTION
It appears that recently Twitter has started checking the User-Agent to decide whether to serve a response to the user.

```
❯ curl -I https://twitter.com/DefraStats
HTTP/2 400
...
<p>
  Please switch to a supported browser to continue using twitter.com. You can see a list of supported browsers in our Help Center.
</p>
```

```
❯ curl -I https://twitter.com/DefraStats -H 'User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36'
HTTP/2 200
```

By pretending to be a reasonably common Chrome browser, we should avoid any potential issues with servers blocking our requests. This change came from a Zendesk ticket where a user was seeing their twitter links marked as broken: https://govuk.zendesk.com/agent/tickets/4442955