### PR TITLE
Return early from check_request if response is nil

### DIFF
--- a/app/lib/link_checker/uri_checker/http_checker.rb
+++ b/app/lib/link_checker/uri_checker/http_checker.rb
@@ -154,7 +154,7 @@ module LinkChecker::UriChecker
       end_time = Time.zone.now
       response_time = end_time - start_time
 
-      return response if report.has_errors?
+      return response if report.has_errors? || response.nil?
 
       add_problem(SlowResponse.new(from_redirect: from_redirect?)) if response_time > RESPONSE_TIME_WARNING
 

--- a/spec/lib/http_checker_spec.rb
+++ b/spec/lib/http_checker_spec.rb
@@ -1,0 +1,10 @@
+require "rails_helper"
+
+RSpec.describe LinkChecker::UriChecker::HttpChecker do
+  let(:uri) { URI("http://example.invalid/") }
+  subject { described_class.new(uri) }
+  it "should not throw an exception if the response is nil" do
+    allow(subject).to receive(:make_request).with(:get).and_return(nil)
+    expect { subject.call }.not_to raise_error
+  end
+end


### PR DESCRIPTION
`make_request` returns nil if Faraday raises an exception. These are already added to the report by `make_request`, so there's no need to do so again here. The return value of `check_request` is not used.

https://trello.com/c/CHUwfu4h/2390-3-fix-nomethoderror-in-link-checker-api