### PR TITLE
Ignore `Faraday::ServerError` errors which occur during data sync

### DIFF
--- a/config/initializers/govuk_error.rb
+++ b/config/initializers/govuk_error.rb
@@ -1,0 +1,3 @@
+GovukError.configure do |config|
+  config.data_sync_excluded_exceptions << "Faraday::ServerError"
+end


### PR DESCRIPTION
We've seen a few hundred `Faraday::ServerError` errors recently,
which only occur between 2am and 4am, and only occur on Staging
and Integration:

https://sentry.io/organizations/govuk/issues/2277923536/?project=202233&query=is%3Aunresolved

It seems reasonable to disable reporting of Faraday connection
errors during the data sync, in which servers are restarted and
temporarily unavailable.