### PR TITLE
Remove startup.sh and make README consistent with current conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,74 +1,30 @@
 # Link Checker API
 
-A web service that takes an input of URIs. It performs a number of checks on
-them to determine whether these are things that should be linked to.
+A web service that takes an input of URIs. It performs a number of checks on them to determine whether these are things that should be linked to.
 
 ## Nomenclature
 
-- **Link**: The consideration of a URI and all resulting redirects
-  that may occur from it.
-- **Check**: The process of taking a URI and checking it as a Link
-  for any problems that may affecting linking to it within content.
-- **Batch**: The functionality to check multiple URIs in a grouping
+- **Link**: The consideration of a URI and all resulting redirects that may occur from it.
+- **Check**: The process of taking a URI and checking it as a Link for any problems that may affecting linking to it within content.
+- **Batch**: The functionality to check multiple URIs in a grouping.
 
 ## Technical documentation
 
-This is a Ruby on Rails application that acts as web service for performing
-links. Communication to and from this service is done through a RESTful JSON
-API. The majority of link checking is done through a background worker than
-uses Sidekiq. There is a webhook functionality for applications to receive
-notifications when link checking is complete.
+This is a Ruby on Rails app, and should follow [our Rails app conventions](https://docs.publishing.service.gov.uk/manual/conventions-for-rails-applications.html).
 
-The HTTP API is defined in [docs/api.md](docs/api.md).
+You can use the [GOV.UK Docker environment](https://github.com/alphagov/govuk-docker) to run the application and its tests with all the necessary dependencies. Follow [the usage instructions](https://github.com/alphagov/govuk-docker#usage) to get started.
 
-### Dependencies
-
-- [PostgreSQL](https://www.postgresql.org/) - provides a database
-- [redis](https://redis.io) - provides queue storage for Sidekiq jobs
-
-### Running the application
-
-Start the web app with:
-
-```bash
-$ ./startup.sh
-```
-
-Application will be available on port 3208 - http://localhost:3208 or if you
-are using the development VM http://link-checker-api.dev.gov.uk
-
-Start the sidekiq worker with:
-
-```bash
-$ bundle exec sidekiq -C config/sidekiq.yml
-```
+**Use GOV.UK Docker to run any commands that follow.**
 
 ### Running the test suite
 
-```bash
-$ bundle exec rspec
+```
+bundle exec rake
 ```
 
-### Report rake task
+### Further documentation
 
-```bash
-$ bundle exec rake report[links.csv]
-```
-
-This will produce a report of all broken links stored in the link checker and when they were last checked.
-
-### Example API output
-
-```
-$ curl -s http://link-checker-api.dev.gov.uk/check\?uri\=https%3A%2F%2Fwww.gov.uk%2F\&synchronous\=true | jq
-{
-  "uri": "https://www.gov.uk/",
-  "status": "ok",
-  "checked": "2017-04-12T18:47:16Z",
-  "errors": {},
-  "warnings": {}
-}
-```
+Check the [docs](docs) directory.
 
 ## Licence
 

--- a/startup.sh
+++ b/startup.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-bundle install
-bundle exec rails s -p 3208


### PR DESCRIPTION
Trello: https://trello.com/c/Psf7EzPB/204-move-away-from-startupsh

This removes the startup.sh script as per the conventions outlined in https://github.com/alphagov/govuk-developer-docs/pull/2897 and updates the README to reflect GOV.UK docker as the preferred way to run GOV.UK apps. I applied some other simplifications to the doc for increased consistency with current GOV.UK Rails app README conventions.