### PR TITLE
Add 'Faraday::ConnectionFailed' error to datasync ignore list

### DIFF
--- a/config/initializers/govuk_error.rb
+++ b/config/initializers/govuk_error.rb
@@ -1,3 +1,6 @@
 GovukError.configure do |config|
-  config.data_sync_excluded_exceptions << "Faraday::ServerError"
+  config.data_sync_excluded_exceptions += [
+    "Faraday::ServerError",
+    "Faraday::ConnectionFailed",
+  ]
 end


### PR DESCRIPTION
This has happened a few times and only seems to occur during the
datasync, where access to Whitehall Admin is volatile.
Resolves https://sentry.io/organizations/govuk/issues/2388239344/?project=202233&query=is%3Aunresolved&statsPeriod=1h