### PR TITLE
Revert rails config defaults to version 6.0

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -25,7 +25,7 @@ module LinkCheckerApi
 
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 6.1
+    config.load_defaults 6.0
 
     # Configuration for the application, engines, and railties goes here.
     #


### PR DESCRIPTION
## Why

Currently 6.1 rails defaults are on integration, and they appear to be causing problems. See kibana links on pr linked to below.

Rather than revert the [whole bump to 6.1.4 ](https://github.com/alphagov/link-checker-api/pull/480), reverting the defaults for now.

