### PR TITLE
Clean database after Pact tests

### DIFF
--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -31,8 +31,13 @@ end
 
 Pact.provider_states_for "GDS API Adapters" do
   set_up do
-    DatabaseCleaner.clean_with :truncation
+    DatabaseCleaner.strategy = :transaction
+    DatabaseCleaner.start
     GDS::SSO.test_user = create(:user, permissions: %w[signin])
+  end
+
+  tear_down do
+    DatabaseCleaner.clean
   end
 
   provider_state "a batch exists with id 99 and uris https://www.gov.uk" do


### PR DESCRIPTION
This commit changes the configuration of the Pact tests.

They were previously configured to truncate the database before each Pact example. However, this meant that the final example in the Pact test suite wouldn't clean up after itself, causing records to be left in the database.

This resulted in subsequent test runs to fail because the test suite expected to begin with an empty database.

This change configures Pact to use the 'transaction' strategy of Database Cleaner to run each example in its own database transaction. The database transaction is started before each Pact test, and is rolled back after each test finishes.

The result is that the database remains clean after a full run of the test suite.