### PR TITLE
Bump i18n

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,7 +157,7 @@ GEM
     httparty (0.18.1)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
-    i18n (1.9.0)
+    i18n (1.9.1)
       concurrent-ruby (~> 1.0)
     json (2.5.1)
     jwt (2.2.3)


### PR DESCRIPTION
i18n version 1.9.0 has been yanked due to a bug so we need to bump to
1.9.1.