### PR TITLE
Update sidekiq-unique-jobs to v7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem "govuk_sidekiq"
 gem "pg"
 gem "plek"
 gem "sidekiq-scheduler"
-gem "sidekiq-unique-jobs", "~> 6" # Latest version is 7.x but this currently breaks the unique options in webhook_worker, will be handled in subsequent PR
+gem "sidekiq-unique-jobs"
 
 group :development, :test do
   gem "byebug" # Comes standard with Rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,9 @@ GEM
     ast (2.4.2)
     awesome_print (1.9.2)
     bindex (0.8.1)
+    brpoplpush-redis_script (0.1.2)
+      concurrent-ruby (~> 1.0, >= 1.0.5)
+      redis (>= 1.0, <= 5.0)
     builder (3.2.4)
     byebug (11.1.3)
     climate_control (1.0.1)
@@ -258,7 +261,7 @@ GEM
     parser (3.1.1.0)
       ast (~> 2.4.1)
     parslet (2.0.0)
-    pg (1.3.2)
+    pg (1.3.3)
     plek (4.0.0)
     pry (0.14.1)
       coderay (~> 1.1)
@@ -400,10 +403,11 @@ GEM
     sidekiq-statsd (2.1.0)
       activesupport
       sidekiq (>= 3.3.1)
-    sidekiq-unique-jobs (6.0.23)
+    sidekiq-unique-jobs (7.1.15)
+      brpoplpush-redis_script (> 0.1.1, <= 2.0.0)
       concurrent-ruby (~> 1.0, >= 1.0.5)
-      sidekiq (>= 4.0, < 7.0)
-      thor (>= 0.20, < 2.0)
+      sidekiq (>= 5.0, < 8.0)
+      thor (>= 0.20, < 3.0)
     simplecov (0.21.2)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -480,7 +484,7 @@ DEPENDENCIES
   rspec-sidekiq
   rubocop-govuk
   sidekiq-scheduler
-  sidekiq-unique-jobs (~> 6)
+  sidekiq-unique-jobs
   simplecov
   timecop
   web-console

--- a/app/workers/check_worker.rb
+++ b/app/workers/check_worker.rb
@@ -2,7 +2,7 @@ class CheckWorker
   include Sidekiq::Worker
   include PerformAsyncInQueue
 
-  sidekiq_options retry: 3, unique: :until_and_while_executing, unique_args: :unique_args
+  sidekiq_options retry: 3, lock: :until_and_while_executing, lock_args_method: :unique_args
 
   sidekiq_retries_exhausted do |msg|
     Check.connection_pool.with_connection do |_|

--- a/app/workers/webhook_worker.rb
+++ b/app/workers/webhook_worker.rb
@@ -4,7 +4,7 @@ end
 class WebhookWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: :webhooks, retry: 4, unique: :until_and_while_executing, unique_args: :unique_args
+  sidekiq_options queue: :webhooks, retry: 4, lock: :until_and_while_executing, lock_args_method: :unique_args
 
   def self.unique_args(args)
     [args[3]] # batch_id

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,17 @@
+Sidekiq.configure_server do |config|
+  config.client_middleware do |chain|
+    chain.add SidekiqUniqueJobs::Middleware::Client
+  end
+
+  config.server_middleware do |chain|
+    chain.add SidekiqUniqueJobs::Middleware::Server
+  end
+
+  SidekiqUniqueJobs::Server.configure(config)
+end
+
+Sidekiq.configure_client do |config|
+  config.client_middleware do |chain|
+    chain.add SidekiqUniqueJobs::Middleware::Client
+  end
+end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -15,3 +15,6 @@ Sidekiq.configure_client do |config|
     chain.add SidekiqUniqueJobs::Middleware::Client
   end
 end
+
+# SidekiqUniqueJobs recommends not testing this behaviour, our tests have previously has caused flakey builds
+SidekiqUniqueJobs.config.enabled = !Rails.env.test?

--- a/spec/workers/check_worker_spec.rb
+++ b/spec/workers/check_worker_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe CheckWorker do
+  specify { expect(described_class).to have_valid_sidekiq_options }
+
   describe "perform" do
     let(:link) { create(:link, id: 123) }
     let(:report) { LinkChecker::UriChecker::Report.new }

--- a/spec/workers/webhook_worker_spec.rb
+++ b/spec/workers/webhook_worker_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe WebhookWorker do
+  specify { expect(described_class).to have_valid_sidekiq_options }
+
   describe "perform" do
     let(:report) { { some: "json" } }
     let(:webhook_uri) { "http://webhooks-rule.org/webhook" }
@@ -24,18 +26,6 @@ RSpec.describe WebhookWorker do
         expect(a_request(:post, webhook_uri)
           .with(headers: { "X-LinkCheckerApi-Signature": expected_signature }))
           .to have_been_requested
-      end
-
-      context "when creating the job multiple times for the same batch" do
-        before do
-          10.times do
-            described_class.perform_async(report, webhook_uri, webhook_secret_token, batch_id)
-          end
-        end
-
-        it "should only put one job on the queue" do
-          expect(WebhookWorker.jobs.size).to eq(1)
-        end
       end
     end
 


### PR DESCRIPTION
Bumping the version of sidekiq-unique jobs to the latest involved a major version change (to v7).

This change requires us to:
* explicitly specify the middleware; and
* rename a couple of the sidekiq options for locking

Additionally, we have decided to remove testing for unique behaviour in tests, as builds were becoming flakey. This is recommended in documentation for the gem (see [here](https://github.com/mhenrixon/sidekiq-unique-jobs#uniqueness)). Instead we can test that the sidekiq options provided in the workers are valid.