### PR TITLE
Remove unused deprecated_columns gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ gem "rails", "7.0.3.1"
 
 gem "activerecord-import"
 gem "addressable"
-gem "deprecated_columns"
 gem "faraday"
 gem "faraday-cookie_jar"
 gem "gds-sso"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,8 +92,6 @@ GEM
       activerecord (>= 5.a)
       database_cleaner-core (~> 2.0.0)
     database_cleaner-core (2.0.1)
-    deprecated_columns (0.1.1)
-      rails (>= 4.0)
     diff-lcs (1.5.0)
     dig_rb (1.0.1)
     digest (3.1.0)
@@ -469,7 +467,6 @@ DEPENDENCIES
   byebug
   climate_control
   database_cleaner
-  deprecated_columns
   factory_bot_rails
   faraday
   faraday-cookie_jar


### PR DESCRIPTION
This was installed as part of the initial set-up of this gem [1] and has not
been used.

[1]: https://github.com/alphagov/link-checker-api/commit/64fed938bd44425d6a998c16d7d3c5744fbe0ad6