### PR TITLE
Remove allow list from Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,25 +4,3 @@ updates:
     directory: /
     schedule:
       interval: daily
-    allow:
-      # Security updates
-      - dependency-name: brakeman
-        dependency-type: direct
-      # Internal gems
-      - dependency-name: "govuk*"
-        dependency-type: direct
-      - dependency-name: "rubocop-govuk"
-        dependency-type: direct
-      - dependency-name: "gds-sso"
-        dependency-type: direct
-      - dependency-name: plek
-        dependency-type: direct
-      # Framework gems
-      - dependency-name: factory_bot_rails
-        dependency-type: direct
-      - dependency-name: pg
-        dependency-type: direct
-      - dependency-name: rails
-        dependency-type: direct
-      - dependency-name: rspec-rails
-        dependency-type: direct


### PR DESCRIPTION
Trello card: https://trello.com/c/DuA0q9Ck/2966-remove-allow-lists-from-dependabot-configs-2