### PR TITLE
Handle argument errors when http request raises argument error for headers having CR/LF characters

### DIFF
--- a/app/lib/link_checker/uri_checker/problem.rb
+++ b/app/lib/link_checker/uri_checker/problem.rb
@@ -45,7 +45,7 @@ module LinkChecker::UriChecker
       UnusualUrl
       NotAvailableOnline
       NoHost
-      FaradayError
+      HttpCommunicationError
       PageNotFound
       PageRequiresLogin
       PageIsUnavailable

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -103,9 +103,9 @@ en:
     singular: This page has a security problem that users may be alerted to.
     redirect: This redirects to a page with a security problem.
 
-  page_failing_to_load:
-    singular: This page is failing to load.
-    redirect: This redirects to a page that isn't loading.
+  technical_error_on_page:
+    singular: This page has a technical error.
+    redirect: This redirects to a page that has a technical error.
 
   determine_if_temporary: Determine if this is a temporary issue or the resource is no longer available.
 

--- a/spec/lib/link_checker_spec.rb
+++ b/spec/lib/link_checker_spec.rb
@@ -142,6 +142,26 @@ RSpec.describe LinkChecker do
       include_examples "has warnings"
     end
 
+    context "header with CR/LF character" do
+      let(:uri) { "http://www.not-gov.uk/header_with_CRLF_character" }
+      before do
+        stub_request(:get, uri)
+          .to_return(headers: { "Invalid" => "A header containing a carriage return \r character" })
+      end
+
+      include_examples "has errors"
+      include_examples "has a problem summary", "Page unavailable"
+    end
+
+    it "does not recue from other argument error" do
+      uri = "http://www.not-gov.uk/raises_argument_error"
+      error = ArgumentError.new("something that's nothing to do with headers and carriage return line feed chars")
+
+      stub_request(:get, uri).to_raise(error)
+
+      expect { described_class.new(uri).call }.to raise_error(error)
+    end
+
     context "slow response" do
       let(:uri) { "http://www.not-gov.uk/slow_response" }
 


### PR DESCRIPTION
Faraday / ruby cannot parse headers which contain CR/LF characters. As this issue appears to exist deep down in the faraday / ruby stack, we should handle the error rather than letting the application alert. This change attempts to handle only those argument errors that roughly fuzzy match the exception string 'header field value cannot include CR/LF' (with a bit of fuzziness in case the exact message changes) but still raise for other exceptions.

[Trello](https://trello.com/c/eZ70YojB/291-fix-for-sentry-errors-header-field-value-cannot-include-cr-lf)