### PR TITLE
Increase test coverage

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -18,3 +18,4 @@ end
 
 # SidekiqUniqueJobs recommends not testing this behaviour, our tests have previously has caused flakey builds
 SidekiqUniqueJobs.config.enabled = !Rails.env.test?
+SidekiqUniqueJobs.config.logger_enabled = !Rails.env.test?

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -12,13 +12,11 @@
 
 development:
   secret_key_base: 36746f0eb3c57b16be0278bdf9a9418ec225ecd5f9a3183697a3dc0dfd3aa1d05d285b3ed42b77c92ae6deee7af6a2b9bc87f119eca9c74810dcc43ddd5eb02b
-  google_api_key: <%= ENV["GOOGLE_API_KEY"] %>
   govuk_rate_limit_token: pfB6uNKYC8sB9PVgBLdwFToN
   govuk_basic_auth_credentials: "test:test"
 
 test:
   secret_key_base: b81a573d7703bfdf5c80f2a201c9e9d7ec5aad3326e252534568e1a82a7fc79a09f0d8ebd5e7e0fb5fc584f6a23440f2be5c986ec723df389ef7527e3e7ffc12
-  google_api_key: test
   govuk_rate_limit_token: pfB6uNKYC8sB9PVgBLdwFToN
   govuk_basic_auth_credentials: "test:test"
 
@@ -26,6 +24,5 @@ test:
 # instead read values from the environment.
 production:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
-  google_api_key: <%= ENV["GOOGLE_API_KEY"] %>
   govuk_rate_limit_token: <%= ENV.fetch("GOVUK_RATE_LIMIT_TOKEN", ENV["RATE_LIMIT_TOKEN"]) %>
   govuk_basic_auth_credentials: <%= ENV["GOVUK_BASIC_AUTH_CREDENTIALS"] %>

--- a/spec/lib/link_checker_spec.rb
+++ b/spec/lib/link_checker_spec.rb
@@ -68,6 +68,13 @@ RSpec.describe LinkChecker do
       include_examples "has no errors"
     end
 
+    context "URI with an unusual format" do
+      let(:uri) { "hxxp://www.gov.uk" }
+      include_examples "has a problem summary", "Unusual URL"
+      include_examples "has warnings"
+      include_examples "has no errors"
+    end
+
     context "URI with supported scheme" do
       let(:uri) { "https://www.gov.uk/ok" }
       include_examples "has no errors"

--- a/spec/lib/link_checker_spec.rb
+++ b/spec/lib/link_checker_spec.rb
@@ -38,9 +38,6 @@ RSpec.describe LinkChecker do
       stub_request(:get, "https://www.gov.uk/ok").to_return(status: 200)
 
       stub_request(:get, "https://www.gov.uk?key[]=value").to_return(status: 200)
-
-      stub_request(:post, "https://safebrowsing.googleapis.com/v4/threatMatches:find?key=test")
-        .to_return(status: 200, body: "{}")
     end
 
     context "invalid URI" do
@@ -308,127 +305,6 @@ RSpec.describe LinkChecker do
           .with(headers: { "Rate-Limit-Token": Rails.application.secrets.govuk_rate_limit_token, "Accept-Encoding": "none" })
       end
     end
-
-    # Commented out as we have disabled the Google Safebrowsing intergration as the API key
-    # wasn't working properly and we were hitting the rate limit in production.
-    #
-    # FIXME uncomment all this once we've found a solution to this
-    #
-    # context "a URL detected by Google Safebrowser API" do
-    #   let(:uri) { "http://malware.testing.google.test/testing/malware/" }
-    #   before do
-    #     stub_request(:get, uri).to_return(status: 200)
-    #     stub_request(:post, "https://safebrowsing.googleapis.com/v4/threatMatches:find?key=test")
-    #       .to_return(status: 200, body: { matches: [{ threatType: "MALWARE" }] }.to_json)
-    #   end
-    #   include_examples "has a problem summary", "Suspicious content"
-    #   include_examples "has warnings"
-    #   include_examples "has no errors"
-    # end
-    #
-    # context "Google Safebrowser API on a gov.uk url" do
-    #   let(:uri) { "http://www.dev.gov.uk/malware.testing.google.test/testing/malware/" }
-    #   before do
-    #     stub_request(:get, uri).to_return(status: 200)
-    #   end
-    #   let(:request) do
-    #     stub_request(:post, "https://safebrowsing.googleapis.com/v4/threatMatches:find?key=test")
-    #   end
-    #
-    #   include_examples "has no warnings"
-    #   include_examples "has no errors"
-    #   it "should not make a request" do
-    #     subject
-    #
-    #     expect(request).to_not have_been_requested
-    #   end
-    # end
-    #
-    # context "Google Safebrowser API on a gov.uk upload url" do
-    #   let(:uri) { "http://www.dev.gov.uk/government/uploads" }
-    #   before do
-    #     stub_request(:get, uri).to_return(status: 200)
-    #   end
-    #   let(:request) do
-    #     stub_request(:post, "https://safebrowsing.googleapis.com/v4/threatMatches:find?key=test")
-    #       .to_return(status: 200, body: "{}")
-    #   end
-    #
-    #   include_examples "has no warnings"
-    #   include_examples "has no errors"
-    #   it "should make a request" do
-    #     subject
-    #
-    #     expect(request).to have_been_requested
-    #   end
-    # end
-    #
-    # context "Google Safebrowser API on an asset-manager upload url" do
-    #   let(:uri) { "https://assets.publishing.service.gov.uk/media/" }
-    #   before do
-    #     stub_request(:get, uri).to_return(status: 200)
-    #   end
-    #   let(:request) do
-    #     stub_request(:post, "https://safebrowsing.googleapis.com/v4/threatMatches:find?key=test")
-    #       .to_return(status: 200, body: "{}")
-    #   end
-    #
-    #   include_examples "has no warnings"
-    #   include_examples "has no errors"
-    #   it "should make a request" do
-    #     subject
-    #
-    #     expect(request).to have_been_requested
-    #   end
-    # end
-    #
-    # context "Google Safebrowser API returns an error" do
-    #   let(:uri) { "http://www.gov.uk/government/uploads" }
-    #   before do
-    #     stub_request(:get, uri).to_return(status: 200)
-    #   end
-    #   let!(:request) do
-    #     stub_request(:post, "https://safebrowsing.googleapis.com/v4/threatMatches:find?key=test")
-    #       .to_return(status: 500, body: "an error", headers: { 'X-Foo' => 'bar' })
-    #   end
-    #
-    #   include_examples "has no warnings"
-    #   include_examples "has no errors"
-    #   it "should log the error to Sentry" do
-    #     expect(GovukError).to receive(:notify)
-    #       .with("Unable to talk to Google Safebrowsing API!",
-    #         extra: {
-    #           status: 500,
-    #           body: 'an error',
-    #           headers: { 'X-Foo' => 'bar' },
-    #         })
-    #
-    #     subject
-    #
-    #     expect(request).to have_been_requested
-    #   end
-    # end
-    #
-    # context "Google Safebrowser API rate limits the request" do
-    #   let(:uri) { "http://www.gov.uk/government/uploads" }
-    #   before do
-    #     stub_request(:get, uri).to_return(status: 200)
-    #   end
-    #   let!(:request) do
-    #     stub_request(:post, "https://safebrowsing.googleapis.com/v4/threatMatches:find?key=test")
-    #       .to_return(status: 429, body: "an error", headers: { 'X-Foo' => 'bar' })
-    #   end
-    #
-    #   include_examples "has no warnings"
-    #   include_examples "has no errors"
-    #   it "should increment the counter in statsd" do
-    #     expect(GovukStatsd).to receive(:increment).with("safebrowsing.rate_limited")
-    #
-    #     subject
-    #
-    #     expect(request).to have_been_requested
-    #   end
-    # end
 
     context "when calling a url that requires authentication" do
       let(:host) { "www.needsauthentication.co.uk" }

--- a/spec/lib/link_checker_spec.rb
+++ b/spec/lib/link_checker_spec.rb
@@ -184,10 +184,38 @@ RSpec.describe LinkChecker do
       include_examples "has no warnings"
     end
 
-    context "4xx status code" do
+    context "401 status code" do
+      let(:uri) { "http://www.not-gov.uk/401" }
+      before { stub_request(:get, uri).to_return(status: 401) }
+      include_examples "has errors", "401 error (page requires login)"
+      include_examples "has no warnings"
+    end
+
+    context "403 status code" do
+      let(:uri) { "http://www.not-gov.uk/403" }
+      before { stub_request(:get, uri).to_return(status: 403) }
+      include_examples "has errors", "403 error (page requires login)"
+      include_examples "has no warnings"
+    end
+
+    context "404 status code" do
       let(:uri) { "http://www.not-gov.uk/404" }
       before { stub_request(:get, uri).to_return(status: 404) }
       include_examples "has errors", "404 error (page not found)"
+      include_examples "has no warnings"
+    end
+
+    context "410 status code" do
+      let(:uri) { "http://www.not-gov.uk/410" }
+      before { stub_request(:get, uri).to_return(status: 410) }
+      include_examples "has errors", "410 error (page not found)"
+      include_examples "has no warnings"
+    end
+
+    context "an unspecified 4xx status code" do
+      let(:uri) { "http://www.not-gov.uk/418" }
+      before { stub_request(:get, uri).to_return(status: 418) }
+      include_examples "has errors", "418 error (page is unavailable)"
       include_examples "has no warnings"
     end
 

--- a/spec/requests/check_spec.rb
+++ b/spec/requests/check_spec.rb
@@ -109,8 +109,6 @@ RSpec.describe "check path", type: :request do
 
     before do
       stub_request(:get, uri).to_return(status: 200)
-      stub_request(:post, "https://safebrowsing.googleapis.com/v4/threatMatches:find?key=test")
-        .to_return(status: 200, body: "{}")
 
       get check_link_path(uri: uri, synchronous: "true")
     end
@@ -126,8 +124,6 @@ RSpec.describe "check path", type: :request do
       create(:check, link: create(:link, uri: uri))
 
       stub_request(:get, uri).to_return(status: 200)
-      stub_request(:post, "https://safebrowsing.googleapis.com/v4/threatMatches:find?key=test")
-        .to_return(status: 200, body: "{}")
 
       get check_link_path(uri: uri, synchronous: true)
     end


### PR DESCRIPTION
Before enabling continuous deployment for this application, we need to increase the test coverage.

This PR increases coverage from 93.58% to 97.28% by removing code that never gets executed and adding additional scenarios where they were not previously being tested.

Additionally, it suppresses some logging to the console that was spamming the output of the tests.

[Trello card](https://trello.com/c/xyWyqqhq/15-enable-continuous-deployment-for-link-checker-api)
