### PR TITLE
Add PR template to warn about Continuous Deployment

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,1 @@
+⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️


### PR DESCRIPTION
This makes the PR template consistent with the other continuously deployed applications.

[Trello card](https://trello.com/c/xyWyqqhq/15-enable-continuous-deployment-for-link-checker-api)