### PR TITLE
Update to Plek 5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,19 +126,19 @@ GEM
       null_logger
       plek (>= 1.9.0)
       rest-client (~> 2.0)
-    gds-sso (17.1.0)
+    gds-sso (17.1.1)
       oauth2 (~> 2.0)
       omniauth (~> 2.1)
       omniauth-oauth2 (~> 1.8)
-      plek (~> 4.0)
+      plek (>= 4, < 6)
       rails (>= 6)
       warden (~> 1.2)
       warden-oauth2 (~> 0.0.1)
     globalid (1.0.0)
       activesupport (>= 5.0)
-    govuk_app_config (4.10.1)
+    govuk_app_config (4.11.0)
       logstasher (~> 2.1)
-      plek (~> 4)
+      plek (>= 4, < 6)
       prometheus_exporter (~> 2.0)
       puma (>= 5.6, < 7.0)
       rack-proxy (~> 0.7)
@@ -256,8 +256,8 @@ GEM
       ast (~> 2.4.1)
     parslet (2.0.0)
     pg (1.4.5)
-    plek (4.1.0)
-    prometheus_exporter (2.0.3)
+    plek (5.0.0)
+    prometheus_exporter (2.0.5)
       webrick
     pry (0.14.1)
       coderay (~> 1.1)
@@ -268,7 +268,7 @@ GEM
     raabro (1.4.0)
     racc (1.6.0)
     rack (2.2.4)
-    rack-protection (3.0.2)
+    rack-protection (3.0.3)
       rack
     rack-proxy (0.7.4)
       rack
@@ -450,7 +450,7 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    zeitwerk (2.6.2)
+    zeitwerk (2.6.6)
 
 PLATFORMS
   aarch64-linux

--- a/app/lib/link_checker/uri_checker/http_checker.rb
+++ b/app/lib/link_checker/uri_checker/http_checker.rb
@@ -260,7 +260,7 @@ module LinkChecker::UriChecker
     end
 
     def gov_uk_uri?
-      @gov_uk_uri ||= Plek.new.website_root.include?(uri.host)
+      @gov_uk_uri ||= Plek.website_root.include?(uri.host)
     end
 
     def gov_uk_upload_uri?

--- a/config/initializers/hosts_with_basic_authorization.rb
+++ b/config/initializers/hosts_with_basic_authorization.rb
@@ -1,3 +1,4 @@
 if Rails.application.secrets.govuk_basic_auth_credentials
-  LinkCheckerApi.hosts_with_basic_authorization[Plek.new.website_uri.host.to_s] = Rails.application.secrets.govuk_basic_auth_credentials
+  govuk_website_host = URI(Plek.website_root).host.to_s
+  LinkCheckerApi.hosts_with_basic_authorization[govuk_website_host] = Rails.application.secrets.govuk_basic_auth_credentials
 end

--- a/spec/lib/link_checker_spec.rb
+++ b/spec/lib/link_checker_spec.rb
@@ -328,7 +328,7 @@ RSpec.describe LinkChecker do
           .to_return(status: 200)
       end
 
-      let(:uri) { "#{Plek.new.website_root}/government/document" }
+      let(:uri) { "#{Plek.website_root}/government/document" }
 
       include_examples "has no errors"
       include_examples "has no warnings"


### PR DESCRIPTION
This updates this app to use Plek version 5 and updates related gems. It fixes backwards compatibility issues and adopts neater methods.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
