### PR TITLE
Hold back bad version 2.8.0 of the `mail` rubygem.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem "faraday-cookie_jar"
 gem "gds-sso"
 gem "govuk_app_config"
 gem "govuk_sidekiq"
+gem "mail", "~> 2.7.1"  # TODO: remove once https://github.com/mikel/mail/issues/1489 is fixed.
 gem "pg"
 gem "plek"
 gem "sentry-sidekiq"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -473,6 +473,7 @@ DEPENDENCIES
   govuk_app_config
   govuk_sidekiq
   listen
+  mail (~> 2.7.1)
   pact
   pact_broker-client
   pg


### PR DESCRIPTION
Version 2.8.0 of the `mail` gem has the wrong filesystem permissions on a few of its .rb files (seems to be the generated tables?), which breaks the app when running as an unprivileged user. We therefore need to hold back this version of the gem until a new version is released that fixes the issue.

The upstream bug is mikel/mail#1489. We can remove this workaround once the bug is fixed.
