### PR TITLE
Add name to pact test workflow

### DIFF
--- a/.github/workflows/pact-verify.yml
+++ b/.github/workflows/pact-verify.yml
@@ -3,6 +3,9 @@
 # This workflow asserts that Pact contract tests are valid against this
 # codebase. It is trigged when changes are made to this project and it
 # is explicitly called by GDS API Adapters when changes are made there.
+
+name: Run Pact tests
+
 on:
   pull_request:
   push:


### PR DESCRIPTION
This give the workflow a human readable name that makes it clearer what the
workflow is used for.
