### PR TITLE
Remove workaround for bad `mail` gem release.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,6 @@ gem "faraday-cookie_jar"
 gem "gds-sso"
 gem "govuk_app_config"
 gem "govuk_sidekiq"
-gem "mail", "~> 2.7.1"  # TODO: remove once https://github.com/mikel/mail/issues/1489 is fixed.
 gem "pg"
 gem "plek"
 gem "sentry-sidekiq"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,6 +94,7 @@ GEM
       activerecord (>= 5.a)
       database_cleaner-core (~> 2.0.0)
     database_cleaner-core (2.0.1)
+    date (3.3.3)
     diff-lcs (1.5.0)
     dig_rb (1.0.1)
     docile (1.4.0)
@@ -178,8 +179,11 @@ GEM
     loofah (2.19.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mail (2.7.1)
+    mail (2.8.0.1)
       mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
     marcel (1.0.2)
     method_source (1.0.0)
     mime-types (3.4.1)
@@ -190,11 +194,12 @@ GEM
     minitest (5.17.0)
     msgpack (1.6.0)
     multi_xml (0.6.0)
-    net-imap (0.3.1)
+    net-imap (0.3.4)
+      date
       net-protocol
     net-pop (0.1.2)
       net-protocol
-    net-protocol (0.1.3)
+    net-protocol (0.2.1)
       timeout
     net-smtp (0.3.3)
       net-protocol
@@ -424,7 +429,7 @@ GEM
     thor (1.2.1)
     tilt (2.0.11)
     timecop (0.9.6)
-    timeout (0.3.0)
+    timeout (0.3.1)
     tins (1.32.1)
       sync
     tzinfo (2.0.5)
@@ -477,7 +482,6 @@ DEPENDENCIES
   govuk_app_config
   govuk_sidekiq
   listen
-  mail (~> 2.7.1)
   pact
   pact_broker-client
   pg


### PR DESCRIPTION
Remove the version constraint that we were using to avoid the bad release of the `mail` gem, now that https://www.github.com/mikel/mail/issues/1489 is fixed.

Update to `2.8.0.1`, which fixes the permissions issue.

Generated with `gsed -i '/gem "mail"/d' && bundle update mail`.
