### PR TITLE
Update pact-verify action to operate with an artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     name: Run Pact tests
     uses: ./.github/workflows/pact-verify.yml
     with:
-      commitish: ${{ github.ref }}
+      ref: ${{ github.ref }}
 
   test-ruby:
     name: Test Ruby

--- a/.github/workflows/pact-verify.yml
+++ b/.github/workflows/pact-verify.yml
@@ -9,10 +9,25 @@ name: Run Pact tests
 on:
   workflow_call:
     inputs:
-      commitish:
+      # The commit / tag of this repo to test against
+      ref:
         required: false
         type: string
         default: main
+      # A GitHub Action artifact which contains the pact definition files
+      # Publishing API calls this action to test new pacts against this
+      # workflow
+      pact_artifact:
+        required: false
+        type: string
+      # When using an artifact this is the file path to the pact that is verified
+      # against
+      pact_artifact_file_to_verify:
+        required: false
+        type: string
+        default: gds_api_adapters-link_checker_api.json
+      # Which version of the pacts to use from the Pact Broker service
+      # This option will be ignored if pact_artifact is set
       pact_consumer_version:
         required: false
         type: string
@@ -37,9 +52,19 @@ jobs:
       - uses: actions/checkout@v3
         with:
           repository: alphagov/link-checker-api
-          ref: ${{ inputs.commitish }}
+          ref: ${{ inputs.ref }}
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
       - run: bundle exec rails db:setup
-      - run: bundle exec rake pact:verify
+      - if: inputs.pact_artifact == ''
+        run: bundle exec rake pact:verify
+        env:
+          PACT_CONSUMER_VERSION: ${{ inputs.pact_consumer_version }}
+      - if: inputs.pact_artifact != ''
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ inputs.pact_artifact }}
+          path: tmp/pacts
+      - if: inputs.pact_artifact != ''
+        run: bundle exec rake pact:verify:at[tmp/pacts/${{ inputs.pact_artifact_file_to_verify }}]


### PR DESCRIPTION
This updates the pact-verify action so that it can accept from a GitHub Action as part of changes described in: https://github.com/alphagov/gds-api-adapters/pull/1188

I made the pact file to be an input with a default as I noticed that across our suite of apps this filename can vary from something straight forward (gds_api_adapters-publishing_api.json) to something very nuanced (gds_api_adapters-bank_holidays_api.json). For these nuanced one an input seemed useful and I wanted to apply the same approach consistently.

I've also updated the name of the parameter "committish" to ref since, across GitHub Actions and GOV.UK usage of them, ref seems to be the more common convention.

_Note: This commit message is a copy and paste across a number of repos_

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
