### PR TITLE
Do not raise when a webhook worker experiences a remote server error

### DIFF
--- a/app/workers/webhook_worker.rb
+++ b/app/workers/webhook_worker.rb
@@ -34,6 +34,8 @@ class WebhookWorker
   rescue Faraday::ClientError => e
     logger.error e.message
     raise RestartWorkerException
+  rescue Faraday::ServerError => e
+    logger.error e.message
   end
 
   def connection

--- a/spec/workers/webhook_worker_spec.rb
+++ b/spec/workers/webhook_worker_spec.rb
@@ -16,16 +16,28 @@ RSpec.describe WebhookWorker do
       # http://www.freeformatter.com/hmac-generator.html
       let(:expected_signature) { "d44d805a16b90922edb48f14ff4e858a5d3e39bd" }
 
-      before do
-        stub_request(:post, webhook_uri).to_return(status: 200)
+      context "with a 200 response code" do
+        before do
+          stub_request(:post, webhook_uri).to_return(status: 200)
 
-        subject.perform(report, webhook_uri, webhook_secret_token, batch_id)
+          subject.perform(report, webhook_uri, webhook_secret_token, batch_id)
+        end
+
+        it "generates a valid signature" do
+          expect(a_request(:post, webhook_uri)
+            .with(headers: { "X-LinkCheckerApi-Signature": expected_signature }))
+            .to have_been_requested
+        end
       end
 
-      it "generates a valid signature" do
-        expect(a_request(:post, webhook_uri)
-          .with(headers: { "X-LinkCheckerApi-Signature": expected_signature }))
-          .to have_been_requested
+      context "with a 5xx response" do
+        before do
+          stub_request(:post, webhook_uri).to_return(status: 504)
+        end
+
+        it "does not raise an error" do
+          expect { subject.perform(report, webhook_uri, webhook_secret_token, batch_id) }.not_to raise_error
+        end
       end
     end
 


### PR DESCRIPTION
This application returns the link checking results to the requesting application through a webhook.

In some cases, the remote server will respond with an error (e.g. a timeout). We don't need to log these to Sentry, since they are outside of this application's control.

Therefore rescuing from the `Faraday::ServerError` raise that can occur in this worker.

[Trello card](https://trello.com/c/VjWY3KPa)