### PR TITLE
Specifically report where Cloudflare block our requests

### DIFF
--- a/app/lib/link_checker/uri_checker/problem.rb
+++ b/app/lib/link_checker/uri_checker/problem.rb
@@ -47,6 +47,7 @@ module LinkChecker::UriChecker
       NoHost
       HttpCommunicationError
       PageNotFound
+      PageBlocksBots
       PageRequiresLogin
       PageIsUnavailable
       PageRespondsWithError

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -64,6 +64,11 @@ en:
     redirect: This redirects to a page not found (404).
   find_content_now: Find where the content is now hosted and link to that instead.
 
+  page_blocks_bots: Page blocks robots
+  page_blocked_bots:
+    singular: Our link checker was blocked from accessing the website.
+    redirect: This redirects to a page that blocked our link checker from accessing the website.
+
   page_requires_login: Page requires login
   login_required_to_view:
     singular: A login is required to view this page.

--- a/spec/lib/link_checker_spec.rb
+++ b/spec/lib/link_checker_spec.rb
@@ -10,9 +10,10 @@ RSpec.describe LinkChecker do
       end
     end
 
-    shared_examples "has errors" do
+    shared_examples "has errors" do |error = nil|
       it "should have errors" do
         expect(subject.errors).to_not be_empty
+        expect(subject.errors).to include(error) if error
       end
     end
 
@@ -202,42 +203,42 @@ RSpec.describe LinkChecker do
     context "401 status code" do
       let(:uri) { "http://www.not-gov.uk/401" }
       before { stub_request(:get, uri).to_return(status: 401) }
-      include_examples "has errors", "401 error (page requires login)"
+      include_examples "has errors", "A login is required to view this page."
       include_examples "has no warnings"
     end
 
     context "403 status code" do
       let(:uri) { "http://www.not-gov.uk/403" }
       before { stub_request(:get, uri).to_return(status: 403) }
-      include_examples "has errors", "403 error (page requires login)"
+      include_examples "has errors", "A login is required to view this page."
       include_examples "has no warnings"
     end
 
     context "404 status code" do
       let(:uri) { "http://www.not-gov.uk/404" }
       before { stub_request(:get, uri).to_return(status: 404) }
-      include_examples "has errors", "404 error (page not found)"
+      include_examples "has errors", "This page was not found (404)."
       include_examples "has no warnings"
     end
 
     context "410 status code" do
       let(:uri) { "http://www.not-gov.uk/410" }
       before { stub_request(:get, uri).to_return(status: 410) }
-      include_examples "has errors", "410 error (page not found)"
+      include_examples "has errors", "This page was not found (404)."
       include_examples "has no warnings"
     end
 
     context "an unspecified 4xx status code" do
       let(:uri) { "http://www.not-gov.uk/418" }
       before { stub_request(:get, uri).to_return(status: 418) }
-      include_examples "has errors", "418 error (page is unavailable)"
+      include_examples "has errors", "This page is unavailable (418)."
       include_examples "has no warnings"
     end
 
     context "5xx status code" do
       let(:uri) { "http://www.not-gov.uk/500" }
       before { stub_request(:get, uri).to_return(status: 500) }
-      include_examples "has errors", "500 (server error)"
+      include_examples "has errors", "This page is responding with an error (500) and won't work for users."
       include_examples "has no warnings"
     end
 


### PR DESCRIPTION
Some linked websites use [Cloudflare Browser Integrity Check](https://developers.cloudflare.com/waf/tools/browser-integrity-check/) to stop automated robots from accessing their site.

This works by responding with a 403 status code and a payload that contains some JavaScript. The JavaScript carries out some checks before reloading the page with a 200 status code.

Our crawler is unable to interact with the JavaScript, so Cloudflare block our access to the site.

In order to stop users thinking these links are actually broken, this change reports a different error when we are blocked by Cloudflare.

[Trello card](https://trello.com/c/4Ek4YxPo)