### PR TITLE
Update fugit to address security alert

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,7 +130,7 @@ GEM
       net-http
     ffi (1.16.3)
     find_a_port (1.0.1)
-    fugit (1.11.0)
+    fugit (1.11.1)
       et-orbi (~> 1, >= 1.2.11)
       raabro (~> 1.4)
     gds-api-adapters (96.0.1)


### PR DESCRIPTION
https://github.com/alphagov/link-checker-api/security/dependabot/54 https://github.com/floraison/fugit/blob/v1.11.1/CHANGELOG.md#fugit-1111-released-2024-08-15

---

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
