### PR TITLE
Introduce 'Danger' response for suspicious domains

### DIFF
--- a/app/lib/link_checker/uri_checker/danger.rb
+++ b/app/lib/link_checker/uri_checker/danger.rb
@@ -1,0 +1,7 @@
+module LinkChecker::UriChecker
+  class Danger < Problem
+    def initialize(**options)
+      super(type: :danger, **options)
+    end
+  end
+end

--- a/app/lib/link_checker/uri_checker/http_checker.rb
+++ b/app/lib/link_checker/uri_checker/http_checker.rb
@@ -35,7 +35,7 @@ module LinkChecker::UriChecker
     end
   end
 
-  class SuspiciousDomain < LinkChecker::UriChecker::Warning
+  class SuspiciousDomain < LinkChecker::UriChecker::Danger
     def initialize(options = {})
       super(summary: :suspicious_destination, message: :website_on_list_of_suspicious_domains, **options)
     end

--- a/app/lib/link_checker/uri_checker/report.rb
+++ b/app/lib/link_checker/uri_checker/report.rb
@@ -29,6 +29,13 @@ module LinkChecker::UriChecker
         .uniq
     end
 
+    def danger
+      problems
+        .select { |problem| problem.type == :danger }
+        .map(&:message)
+        .uniq
+    end
+
     def errors
       problems
         .select { |problem| problem.type == :error }

--- a/spec/lib/link_checker_spec.rb
+++ b/spec/lib/link_checker_spec.rb
@@ -30,6 +30,13 @@ RSpec.describe LinkChecker do
       end
     end
 
+    shared_examples "has danger" do |danger = nil|
+      it "should have danger" do
+        expect(subject.danger).to_not be_empty
+        expect(subject.danger).to include(danger) if danger
+      end
+    end
+
     shared_examples "has a problem summary" do |summary|
       it "should have a problem summary of #{summary}" do
         expect(subject.problem_summary).to eq(summary)
@@ -102,7 +109,7 @@ RSpec.describe LinkChecker do
       let(:uri) { "https://malicious.example.com" }
       before { stub_request(:get, uri).to_return(status: 200) }
       include_examples "has a problem summary", "Suspicious Destination"
-      include_examples "has warnings"
+      include_examples "has danger"
       include_examples "has no errors"
     end
 


### PR DESCRIPTION
The publishing teams have asked for this change. It will allow the api to respond with "danger" when a link is suspicious which means the teams can separate out these links to disallow them completely. 

Will need supporting changes to the pact tests in gds api adapters