### PR TITLE
Switch to using "Unix epoch" for batch_id

### DIFF
--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -1,4 +1,6 @@
 class Batch < ApplicationRecord
+  before_create :set_unique_timestamp_id
+
   has_many :batch_checks, -> { order(:order) }
   has_many :checks, through: :batch_checks
 
@@ -29,5 +31,24 @@ class Batch < ApplicationRecord
       webhook_secret_token,
       id,
     )
+  end
+
+private
+
+  def set_unique_timestamp_id
+    return if id.present? # Use provided ID if already set, e.g. in tests
+
+    current_epoch = Time.zone.now.to_i
+
+    # Use a transaction to ensure atomicity
+    self.id = self.class.transaction do
+      # Check if current epoch time is already taken
+      if self.class.exists?(id: current_epoch)
+        # If taken, get the highest ID and increment
+        self.class.maximum(:id).to_i + 1
+      else
+        current_epoch
+      end
+    end
   end
 end


### PR DESCRIPTION
This commit adds logic to set the auto-generated batch ID field to the current epoch / Unix timestamp, instead of just auto incrementing +1 from the previous max ID.

This solves two problem areas with Link Checker API's integration with Whitehall:

1. Local development. If a dev has replicated production Whitehall data, but not replicated production Link Checker API data, then when generating link check reports via Whitehall's UI, Link Checker API will 'callback' with a batch ID that already exists in Whitehall's DB, and thus will update a link check report that is associated with a completely different edition than the one intended.
2. Integration & Staging. As above, if Link Checker API's database is copied over before Whitehall's database, then Whitehall can be 'ahead' of Link Checker API in non-production environments, causing the first few link checker API calls to fail in unexpected ways. The sync order was changed in alphagov/govuk-helm-charts#3058 to accommodate this, but it's still quite a brittle setup.

Instead of an enumerable batch ID, we could instead have Link Checker API generate some sort of GUID which could be passed to Whitehall's callback, but that would require Pact changes, as well as other wider API changes (e.g. current 'GET' methods use batch ID as the identifier and would need to be swapped to use the GUID). This approach was explored in #982 but decided against in favour of this PR.

Our first attempt at a timestamp-based ID was to go for something human readable, e.g. `20250301103000` (which would be a batch created on 1st March 2025 at roughly 10:30am). However, that would require changing the `id` field from an 'integer' to a 'bigint', and again could have ramifications elsewhere (such as in Whitehall, where the `batch_id` is stored locally as an 'integer'), so would require DB migrations across multiple applications.

We were therefore limited to 4-byte numbers. The Unix epoch timestamp fits the bill perfectly: we now always have a date-ordered batch, which accounts for data sync issues or empty Link Checker API databases locally, etc. A link checker API 'batch' should always have a newer batch ID than whatever Whitehall may have locally, by the time it is next called (i.e. locally or post-data-sync). And no database or data migration is required, since the pre-epoch batch IDs are still perfectly valid.

Trello: https://trello.com/c/tmnht4P1

---

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
