### PR TITLE
Don't make HTTP requests to suspicious domains

### DIFF
--- a/app/lib/link_checker/uri_checker/http_checker.rb
+++ b/app/lib/link_checker/uri_checker/http_checker.rb
@@ -113,10 +113,12 @@ module LinkChecker::UriChecker
         return add_problem(NoHost.new(from_redirect: from_redirect?))
       end
 
+      check_suspicious_domains
+      return report if report.problems.any?
+
       check_redirects
       check_credentials_in_uri
       check_top_level_domain
-      check_suspicious_domains
 
       check_request
       return report if report.has_errors?

--- a/spec/lib/http_checker_spec.rb
+++ b/spec/lib/http_checker_spec.rb
@@ -7,4 +7,14 @@ RSpec.describe LinkChecker::UriChecker::HttpChecker do
     allow(subject).to receive(:make_request).with(:get).and_return(nil)
     expect { subject.call }.not_to raise_error
   end
+
+  context "a suspicious domain is passed" do
+    let(:uri) { URI("http://malicious.example.com/foo") }
+    subject { described_class.new(uri) }
+    it "should not request the URI if it is a suspicious domain" do
+      expect(subject).not_to receive(:make_request)
+      report = subject.call
+      expect(report.problems).to match([LinkChecker::UriChecker::SuspiciousDomain])
+    end
+  end
 end


### PR DESCRIPTION
The Link Checker API logic was continuing to go through all the other link checks (checking for redirects, reachability, etc). But suspicious domains can be dangerous domains. We don't want to send a HTTP request to those domains, period.

So now we return early if a link is hosted on a suspicious domain.

Trello: https://trello.com/c/tmnht4P1

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
