### PR TITLE
Fix race condition in Batch ID assignment

### DIFF
--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -42,7 +42,9 @@ private
 
     # Use a transaction to ensure atomicity
     self.id = self.class.transaction do
-      # Check if current epoch time is already taken
+      # Lock the rows while checking for an existing ID
+      self.class.connection.execute("LOCK TABLE #{self.class.table_name} IN ACCESS EXCLUSIVE MODE")
+
       if self.class.exists?(id: current_epoch)
         # If taken, get the highest ID and increment
         self.class.maximum(:id).to_i + 1


### PR DESCRIPTION
Ensure unique ID generation by locking the batches table with `ACCESS EXCLUSIVE MODE` to prevent concurrent transactions from assigning the same ID. This resolves a PG::UniqueViolation error (introduced in #983) when creating batches simultaneously.

## More details

- The set_unique_timestamp_id callback is designed to assign a unique id based on the current epoch time.
- It checks if the current epoch time is already taken. If so, it assigns self.class.maximum(:id).to_i + 1.
- The check (self.class.exists?(id: current_epoch)) and the subsequent self.class.maximum(:id).to_i + 1 are performed inside a transaction, but this does not prevent a race condition when multiple transactions execute concurrently.

If two transactions start at the same time:

- Both check self.class.exists?(id: current_epoch), which returns false.
- Both proceed with self.id = current_epoch, leading to a PG::UniqueViolation when they try to insert.

The transaction didn't fix this because:

- Transactions in PostgreSQL do not lock reads unless you explicitly use SELECT ... FOR UPDATE.
- The self.class.exists?(id: current_epoch) check does not lock rows, so multiple transactions can read the same state before inserting.
- By the time self.class.maximum(:id).to_i + 1 is executed, another transaction may have already inserted a record with that ID.

---

Trello: https://trello.com/c/tmnht4P1

Resolves:
- https://govuk.sentry.io/issues/6441785767/?alert_rule_id=9401721&alert_type=issue&environment=production&notification_uuid=37baf2e4-ade5-425d-9868-dbc8ef52e177&project=202259&referrer=slack
- https://govuk.sentry.io/issues/6441785741/events/6c14e97233074ada8c5f2a0391b53898/?project=202233&query=issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=previous-event&stream_index=0

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
