### PR TITLE
Update guidance for "Page blocks robots" error

### DIFF
--- a/app/lib/link_checker/uri_checker/http_checker.rb
+++ b/app/lib/link_checker/uri_checker/http_checker.rb
@@ -55,7 +55,7 @@ module LinkChecker::UriChecker
 
   class PageBlocksBots < LinkChecker::UriChecker::Warning
     def initialize(options = {})
-      super(summary: :page_blocks_bots, message: :page_blocked_bots, **options)
+      super(summary: :page_blocks_bots, message: :page_blocked_bots, suggested_fix: :how_to_fix_page_blocks_bots, **options)
     end
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -66,8 +66,9 @@ en:
 
   page_blocks_bots: Page blocks robots
   page_blocked_bots:
-    singular: Our link checker was blocked from accessing the website.
-    redirect: This redirects to a page that blocked our link checker from accessing the website.
+    singular: Our automatic link checker was blocked from accessing the website.
+    redirect: This redirects to a page that blocked our automatic link checker from accessing.
+  how_to_fix_page_blocks_bots: Check the link yourself to make sure it works.
 
   page_requires_login: Page requires login
   login_required_to_view:

--- a/spec/lib/link_checker_spec.rb
+++ b/spec/lib/link_checker_spec.rb
@@ -226,7 +226,7 @@ RSpec.describe LinkChecker do
         )
       end
       include_examples "has no errors"
-      include_examples "has warnings", "Our link checker was blocked from accessing the website."
+      include_examples "has warnings", "Our automatic link checker was blocked from accessing the website."
     end
 
     context "403 status code without Cloudflare challenge header" do


### PR DESCRIPTION
This was causing confusion for publishers. Updated guidance proposed here: https://trello.com/c/Ep0YKe0w/28-improve-broken-links-checker-guidance

The proposed guidance doesn't quite align with the Link Checker API / Whitehall architecture, so I've taken inspiration from it rather than used it directly. This, in combination with surfacing the full error messages in https://github.com/alphagov/whitehall/pull/10093, should make things much clearer for users.

Trello: https://trello.com/c/uIpabmKR/846-improve-content-design-of-link-check-reports

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
