### PR TITLE
Memoize old checks in `CleanupJob`

### DIFF
--- a/app/sidekiq/cleanup_job.rb
+++ b/app/sidekiq/cleanup_job.rb
@@ -21,7 +21,7 @@ private
   end
 
   def old_checks
-    Check.where("completed_at < ?", OLD_CHECK_THRESHOLD.ago)
+    @old_checks ||= Check.where("completed_at < ?", OLD_CHECK_THRESHOLD.ago)
   end
 
   def old_batches


### PR DESCRIPTION
We were querying for checks to delete twice, once using the result to delete foreign key relations and the other time to delete the checks themselves.

It is possible to checks meeting the criteria changed between both runs, resulting in a foreign key constraint error when deleting some checks as the batch had not been deleted.

Memoizing the old checks query result, so we always target the same records on both deletions.

This may resolve [a Sentry error](https://govuk.sentry.io/issues/5919685208/?referrer=slack&notification_uuid=3bc63041-060e-45f5-9696-8fbdeddb050b&alert_rule_id=12539537&alert_type=issue).