### PR TITLE
Warn on links to 'internal' domains (WHIT-1963)

### DIFF
--- a/app/lib/link_checker/uri_checker/problem.rb
+++ b/app/lib/link_checker/uri_checker/problem.rb
@@ -45,6 +45,7 @@ module LinkChecker::UriChecker
       UnusualUrl
       NotAvailableOnline
       NoHost
+      InternalDomain
       HttpCommunicationError
       PageNotFound
       PageBlocksBots

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -53,6 +53,12 @@ en:
     singular: This link is hosted on a domain which is on our list of suspicious domains
     redirect: This redirects to a website which is on our list of suspicious domains
 
+  internal_domain: Internal domain
+
+  website_on_internal_domain:
+    singular: This links to an internal domain that is not intended to be viewed by the public.
+    redirect: This redirects to an internal domain that is not intended to be viewed by the public.
+
   slow_page: Slow page
   page_is_slow:
     singular: This page is slow loading and may frustrate users.

--- a/spec/lib/link_checker_spec.rb
+++ b/spec/lib/link_checker_spec.rb
@@ -105,6 +105,14 @@ RSpec.describe LinkChecker do
       include_examples "has no errors"
     end
 
+    context "host is internal" do
+      let(:uri) { "https://integration.publishing.service.gov.uk/foo/bar" }
+      before { stub_request(:get, uri).to_return(status: 200) }
+      include_examples "has a problem summary", "Internal domain"
+      include_examples "has warnings"
+      include_examples "has no errors"
+    end
+
     context "domain is risky" do
       let(:uri) { "https://malicious.example.com" }
       before { stub_request(:get, uri).to_return(status: 200) }


### PR DESCRIPTION
Whitehall currently has its own special validation rules to prevent publishers from linking to the `whitehall-admin.publishing.service.gov.uk` domain: this usually indicates that the publisher should have linked to an absolute path instead (e.g. `/government/news/foo` or `/government/news/123456`).

Whitehall's validation: https://github.com/alphagov/whitehall/blob/977901c73ee08d2d09160f41eb7dad0503aea10c/app/validators/govspeak_link_validator.rb#L10-L12

This kind of 'internal link' checking is better off being consolidated into Link Checker API, which should mean that we can eliminate the competing 'broken links' areas of the Whitehall document sidebar (we currently have one area reporting on Whitehall's validation rules for links, and another one reporting on Link Checker API reports).

---

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
