### PR TITLE
Remove pin for `sidekiq-unique-jobs`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem "pg"
 gem "plek"
 gem "sentry-sidekiq"
 gem "sidekiq-scheduler"
-gem "sidekiq-unique-jobs", "< 8.0.12"
+gem "sidekiq-unique-jobs"
 
 group :development, :test do
   gem "brakeman"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -799,7 +799,7 @@ DEPENDENCIES
   rubocop-govuk
   sentry-sidekiq
   sidekiq-scheduler
-  sidekiq-unique-jobs (< 8.0.12)
+  sidekiq-unique-jobs
   simplecov
   timecop
   web-console


### PR DESCRIPTION
This dependency was pinned to a specific version in 6170c25d8efb0ec03b238448c120820f6eac6e6b, however dependabot has bumped it anyway.

We aren't aware of any issues as a result of this version change, so removing the pinning as it now seems pointless.