### PR TITLE
Remove job/worker aliases

### DIFF
--- a/app/sidekiq/check_job.rb
+++ b/app/sidekiq/check_job.rb
@@ -57,5 +57,3 @@ class CheckJob
     end
   end
 end
-
-CheckWorker = CheckJob

--- a/app/sidekiq/cleanup_job.rb
+++ b/app/sidekiq/cleanup_job.rb
@@ -28,5 +28,3 @@ private
     Batch.where(id: BatchCheck.select(:batch_id).where(check: old_checks))
   end
 end
-
-CleanupWorker = CleanupJob

--- a/app/sidekiq/webhook_job.rb
+++ b/app/sidekiq/webhook_job.rb
@@ -49,5 +49,3 @@ class WebhookJob
     OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new("sha1"), key, body)
   end
 end
-
-WebhookWorker = WebhookJob


### PR DESCRIPTION
These were added in 21b9d8b3eecfc0ae4a9e842acbcce2cb73a40c61 when the workers were renamed to jobs, so the enqueued jobs would not fail when the class was renamed.

They can now be removed as all the enqueued jobs would have finished a long time ago.